### PR TITLE
[Maintenance] Expose behat classes in autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Sylius\\PriceHistoryPlugin\\": "src/"
+            "Sylius\\PriceHistoryPlugin\\": "src/",
+            "Tests\\Sylius\\PriceHistoryPlugin\\Behat\\": "tests/Behat/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
Investigated a bit as per [the comment](https://github.com/Sylius/PriceHistoryPlugin/pull/15#discussion_r1097213546) and it indeed seems to be the case.