### PR TITLE
[LowestPriceBeforeTheDiscount][API] Lowest price before discount processing

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -40,5 +40,18 @@
             <argument type="service" id="event_dispatcher" />
             <argument>%sylius_price_history.expired_logs_removal_batch_size%</argument>
         </service>
+
+        <service
+            id="Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface"
+            class="Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessor"
+        >
+            <argument type="service" id="sylius_price_history.repository.channel_pricing_log_entry" />
+            <argument type="service" id="sylius.repository.channel" />
+        </service>
+
+        <service
+            id="Sylius\PriceHistoryPlugin\Application\Provider\ProductVariantPriceProviderInterface"
+            class="Sylius\PriceHistoryPlugin\Application\Provider\ProductVariantPriceProvider"
+        />
     </services>
 </container>

--- a/config/services/listeners.xml
+++ b/config/services/listeners.xml
@@ -21,6 +21,14 @@
             <tag name="doctrine.event_listener" event="onFlush" lazy="true" />
         </service>
 
+        <service
+            id="sylius_price_history.entity_listener.channel_pricing_change"
+            class="Sylius\PriceHistoryPlugin\Infrastructure\EntityListener\ChannelPricingChangeListener"
+        >
+            <argument type="service" id="Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface" />
+            <tag name="doctrine.orm.entity_listener" event="postUpdate" entity="Sylius\Component\Core\Model\ChannelPricing" />
+        </service>
+
         <service id="Sylius\PriceHistoryPlugin\Infrastructure\EventListener\BeforeDenormalizationChannelValidationListener">
             <argument type="service" id="validator" />
             <argument type="service" id="sylius.custom_factory.channel" />

--- a/config/services/serializers.xml
+++ b/config/services/serializers.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <services>
+        <service id="Sylius\PriceHistoryPlugin\Infrastructure\Serializer\ProductVariantNormalizer">
+            <argument type="service" id="Sylius\PriceHistoryPlugin\Application\Provider\ProductVariantPriceProviderInterface" />
+            <argument type="service" id="sylius.section_resolver.uri_based_section_resolver" />
+            <tag name="serializer.normalizer" priority="128" />
+        </service>
+    </services>
+</container>

--- a/features/product/viewing_products/seeing_products_lowest_price_before_the_discount.feature
+++ b/features/product/viewing_products/seeing_products_lowest_price_before_the_discount.feature
@@ -7,20 +7,20 @@ Feature: Seeing the product's lowest price before the discount
     Background:
         Given the store operates on a single channel in "United States"
 
-    @todo
+    @api
     Scenario: Not seeing the lowest price information on a product with no discount
         Given the store has a product "Wyborowa Vodka" priced at "$21.00"
         When I check this product's details
         Then I should not see information about its lowest price
 
-    @todo
+    @api
     Scenario: Seeing the lowest price information on a product that has a single discount
         Given the store has a product "Wyborowa Vodka" priced at "$37.00"
         And this product's price changed to "$21.00" and original price changed to "$37.00"
         When I check this product's details
         Then I should see "$37.00" as its lowest price before the discount
 
-    @todo
+    @api
     Scenario: Seeing the lowest price information on a product that has a discount, and then seeing the discount change
         Given the store has a product "Wyborowa Vodka" priced at "$37.00"
         And this product's price changed to "$21.00" and original price changed to "$37.00"
@@ -28,7 +28,7 @@ Feature: Seeing the product's lowest price before the discount
         When I check this product's details
         Then I should see "$21.00" as its lowest price before the discount
 
-    @todo
+    @api
     Scenario: Seeing the lowest price information on a product that has a discount, over a month passes, and then seeing the discount change
         Given it is "2023-03-14" now
         And the store has a product "Wyborowa Vodka" priced at "$42.00"
@@ -38,7 +38,7 @@ Feature: Seeing the product's lowest price before the discount
         When I check this product's details
         Then I should see "$21.00" as its lowest price before the discount
 
-    @todo
+    @api
     Scenario: Seeing the lowest price information on a product that has a discount and the one of the previous promotions ended over 30 days ago
         Given it is "2022-12-01" now
         And the store has a product "Wyborowa Vodka" priced at "$42.00"
@@ -50,7 +50,7 @@ Feature: Seeing the product's lowest price before the discount
         When I check this product's details
         Then I should see "$39.00" as its lowest price before the discount
 
-    @todo
+    @api
     Scenario: Seeing the lowest price information on a product that has a discount and the previous promotion ended over 30 days ago
         Given it is "2022-12-01" now
         And the store has a product "Wyborowa Vodka" priced at "$42.00"
@@ -62,7 +62,7 @@ Feature: Seeing the product's lowest price before the discount
         When I check this product's details
         Then I should see "$42.00" as its lowest price before the discount
 
-    @todo
+    @api
     Scenario: Not seeing the lowest price information on a product that had a discount and the discount was removed
         Given the store has a product "Wyborowa Vodka" priced at "$37.00"
         And this product's price changed to "$21.00" and original price changed to "$37.00"
@@ -70,7 +70,7 @@ Feature: Seeing the product's lowest price before the discount
         When I check this product's details
         Then I should not see information about its lowest price
 
-    @todo
+    @api
     Scenario: Seeing the lowest price information on a product that had a discount, the discount was removed, the price changed below the discount price, the price changed back to the start value and then the less attractive discount was added
         Given the store has a product "Wyborowa Vodka" priced at "$37.00"
         And this product's price changed to "$21.00" and original price changed to "$37.00"
@@ -81,7 +81,7 @@ Feature: Seeing the product's lowest price before the discount
         When I check this product's details
         Then I should see "$10.00" as its lowest price before the discount
 
-    @todo
+    @api
     Scenario: Seeing the lowest price information on a product that had a discount, the price was changed below previous discount while a less attractive discount was added and a less attractive discount was added
         Given the store has a product "Wyborowa Vodka" priced at "$37.00"
         And this product's price changed to "$20.00" and original price changed to "$37.00"
@@ -90,7 +90,7 @@ Feature: Seeing the product's lowest price before the discount
         When I check this product's details
         Then I should see "$20.00" as its lowest price before the discount
 
-    @todo
+    @api
     Scenario: Seeing the lowest price information on a product with same discount repeated
         Given the store has a product "Wyborowa Vodka" priced at "$37.00"
         And this product's price changed to "$20.00" and original price changed to "$37.00"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,5 +14,4 @@ parameters:
         - 'src/DependencyInjection/Configuration.php'
     ignoreErrors:
         - '/Method Sylius\\PriceHistoryPlugin\\Domain\\Model\\\w+\:\:getId\(\) has no return type specified./'
-        - '/Method Sylius\\PriceHistoryPlugin\\Application\\Factory\\ChannelPricingLogEntryFactory\:\:create\(\) should return Sylius\\PriceHistoryPlugin\\Domain\\Model\\ChannelPricingLogEntryInterface but returns object./'
         - '/Method Sylius\\PriceHistoryPlugin\\Infrastructure\\Doctrine\\ORM\\ChannelPricingLogEntryRepository\:\:findOlderThan\(\) should return array\<Sylius\\PriceHistoryPlugin\\Domain\\Model\\ChannelPricingLogEntryInterface\> but returns mixed./'

--- a/psalm.xml
+++ b/psalm.xml
@@ -26,6 +26,24 @@
             </errorLevel>
         </InvalidStringClass>
 
-        <PropertyNotSetInConstructor errorLevel="info" />
+        <PropertyNotSetInConstructor>
+            <errorLevel type="info">
+                <file name="src/Infrastructure/Serializer/ProductVariantNormalizer.php" />
+                <file name="src/Infrastructure/Cli/Command/ClearPriceHistoryCommand.php" />
+            </errorLevel>
+        </PropertyNotSetInConstructor>
+
+        <DeprecatedClass>
+            <errorLevel type="info">
+                <referencedClass name="Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface" /> <!-- deprecated in Symfony 6.1, probably a bug in psalm, as this is referenced as DeprecatedClass, not an interface -->
+            </errorLevel>
+        </DeprecatedClass>
+
+        <DeprecatedInterface>
+            <errorLevel type="info">
+                <referencedClass name="Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface" /> <!-- deprecated in Symfony 6.1 -->
+                <referencedClass name="Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface" /> <!-- deprecated in Symfony 6.1 -->
+            </errorLevel>
+        </DeprecatedInterface>
     </issueHandlers>
 </psalm>

--- a/spec/Application/Processor/ProductLowestPriceBeforeDiscountProcessorSpec.php
+++ b/spec/Application/Processor/ProductLowestPriceBeforeDiscountProcessorSpec.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\PriceHistoryPlugin\Application\Processor;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingLogEntry;
+use Sylius\PriceHistoryPlugin\Infrastructure\Doctrine\ORM\ChannelPricingLogEntryRepositoryInterface;
+
+final class ProductLowestPriceBeforeDiscountProcessorSpec extends ObjectBehavior
+{
+    function let(
+        ChannelPricingLogEntryRepositoryInterface $channelPricingLogEntryRepository,
+        ChannelRepositoryInterface $channelRepository,
+    ): void
+    {
+        $this->beConstructedWith($channelPricingLogEntryRepository, $channelRepository);
+    }
+
+    function it_implements_product_lowest_price_processor_interface(): void
+    {
+        $this->shouldImplement(ProductLowestPriceBeforeDiscountProcessorInterface::class);
+    }
+
+    function it_sets_lowest_price_before_discount_to_null_if_original_price_is_null(
+        ChannelPricingLogEntryRepositoryInterface $channelPricingLogEntryRepository,
+        ChannelRepositoryInterface $channelRepository,
+        ChannelPricingInterface $channelPricing,
+    ): void {
+        $channelPricing->getOriginalPrice()->willReturn(null);
+        $channelPricing->getPrice()->willReturn(2100);
+
+        $channelRepository->findOneByCode(Argument::any())->shouldNotBeCalled();
+        $channelPricingLogEntryRepository->findLatestOneByChannelPricing($channelPricing)->shouldNotBeCalled();
+        $channelPricingLogEntryRepository->findLowestPriceInPeriod(Argument::cetera())->shouldNotBeCalled();
+
+        $channelPricing->getChannelCode()->shouldNotBeCalled();
+        $channelPricing->setLowestPriceBeforeDiscount(null)->shouldBeCalled();
+
+        $this->process($channelPricing);
+    }
+
+    function it_sets_lowest_price_before_discount_to_null_if_price_is_equal_original_price(
+        ChannelPricingLogEntryRepositoryInterface $channelPricingLogEntryRepository,
+        ChannelRepositoryInterface $channelRepository,
+        ChannelPricingInterface $channelPricing,
+    ): void {
+        $channelPricing->getOriginalPrice()->willReturn(2100);
+        $channelPricing->getPrice()->willReturn(2100);
+
+        $channelRepository->findOneByCode(Argument::any())->shouldNotBeCalled();
+        $channelPricingLogEntryRepository->findLatestOneByChannelPricing($channelPricing)->shouldNotBeCalled();
+        $channelPricingLogEntryRepository->findLowestPriceInPeriod(Argument::cetera())->shouldNotBeCalled();
+
+        $channelPricing->getChannelCode()->shouldNotBeCalled();
+        $channelPricing->setLowestPriceBeforeDiscount(null)->shouldBeCalled();
+
+        $this->process($channelPricing);
+    }
+
+    function it_sets_lowest_price_before_discount_to_null_if_price_is_greater_than_original_price(
+        ChannelPricingLogEntryRepositoryInterface $channelPricingLogEntryRepository,
+        ChannelRepositoryInterface $channelRepository,
+        ChannelPricingInterface $channelPricing,
+    ): void {
+        $channelPricing->getOriginalPrice()->willReturn(2100);
+        $channelPricing->getPrice()->willReturn(3700);
+
+        $channelRepository->findOneByCode(Argument::any())->shouldNotBeCalled();
+        $channelPricingLogEntryRepository->findLatestOneByChannelPricing($channelPricing)->shouldNotBeCalled();
+        $channelPricingLogEntryRepository->findLowestPriceInPeriod(Argument::cetera())->shouldNotBeCalled();
+
+        $channelPricing->getChannelCode()->shouldNotBeCalled();
+        $channelPricing->setLowestPriceBeforeDiscount(null)->shouldBeCalled();
+
+        $this->process($channelPricing);
+    }
+
+    function it_sets_lowest_price_before_discount_to_null_if_there_is_no_log_entries(
+        ChannelPricingLogEntryRepositoryInterface $channelPricingLogEntryRepository,
+        ChannelRepositoryInterface $channelRepository,
+        ChannelInterface $channel,
+        ChannelPricingInterface $channelPricing,
+    ): void {
+        $channelPricing->getOriginalPrice()->willReturn(3700);
+        $channelPricing->getPrice()->willReturn(2100);
+        $channelPricing->getChannelCode()->willReturn('WEB');
+        $channel->getLowestPriceForDiscountedProductsCheckingPeriod()->shouldNotBeCalled();
+
+        $channelRepository->findOneByCode('WEB')->willReturn($channel);
+        $channelPricingLogEntryRepository->findLatestOneByChannelPricing($channelPricing)->willReturn(null);
+        $channelPricingLogEntryRepository->findLowestPriceInPeriod(Argument::cetera())->shouldNotBeCalled();
+
+        $channelPricing->setLowestPriceBeforeDiscount(null)->shouldBeCalled();
+
+        $this->process($channelPricing);
+    }
+
+    function it_sets_lowest_price_before_discount_to_lowest_price_found_in_the_given_period_if_price_is_less_than_original_price(
+        ChannelPricingLogEntryRepositoryInterface $channelPricingLogEntryRepository,
+        ChannelRepositoryInterface $channelRepository,
+        ChannelInterface $channel,
+        ChannelPricingInterface $channelPricing,
+        ChannelPricingLogEntry $latestLogEntry,
+    ): void {
+        $channelPricing->getOriginalPrice()->willReturn(3700);
+        $channelPricing->getPrice()->willReturn(2100);
+        $channelPricing->getChannelCode()->willReturn('WEB');
+
+        $channelRepository->findOneByCode('WEB')->willReturn($channel);
+        $channel->getLowestPriceForDiscountedProductsCheckingPeriod()->willReturn(30);
+
+        $unformattedDate = new \DateTimeImmutable();
+        $latestLogEntry->getLoggedAt()->willReturn($unformattedDate);
+        $loggedAt = new \DateTimeImmutable($unformattedDate->format('Y-m-d H:i:s'));
+        $startDate = $loggedAt->sub(new \DateInterval(sprintf('P%dD', 30)));
+
+        $latestLogEntry->getChannelPricing()->willReturn($channelPricing);
+        $latestLogEntry->getLoggedAt()->willReturn($loggedAt);
+        $latestLogEntry->getId()->willReturn(1234);
+
+        $channelPricingLogEntryRepository->findLatestOneByChannelPricing($channelPricing)->willReturn($latestLogEntry);
+        $channelPricingLogEntryRepository
+            ->findLowestPriceInPeriod(1234, $channelPricing, $startDate)
+            ->willReturn(6900)
+        ;
+
+        $channelPricing->setLowestPriceBeforeDiscount(6900)->shouldBeCalled();
+
+        $this->process($channelPricing);
+    }
+}

--- a/spec/Application/Provider/ProductVariantPriceProviderSpec.php
+++ b/spec/Application/Provider/ProductVariantPriceProviderSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\PriceHistoryPlugin\Application\Provider;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Exception\MissingChannelConfigurationException;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\PriceHistoryPlugin\Application\Provider\ProductVariantPriceProviderInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
+
+final class ProductVariantPriceProviderSpec extends ObjectBehavior
+{
+    function it_implements_product_variant_price_provider_interface(): void
+    {
+        $this->shouldImplement(ProductVariantPriceProviderInterface::class);
+    }
+
+    function it_returns_the_lowest_price_before_discount(
+        ChannelInterface $channel,
+        ChannelPricingInterface $channelPricing,
+        ProductVariantInterface $productVariant,
+    ): void {
+        $productVariant->getChannelPricingForChannel($channel)->willReturn($channelPricing);
+        $channelPricing->getLowestPriceBeforeDiscount()->willReturn(2100);
+
+        $this->getLowestPriceBeforeDiscount($productVariant, $channel)->shouldReturn(2100);
+    }
+
+    function it_throws_a_channel_not_defined_exception_if_there_is_no_channel_pricing_when_providing_the_lowest_price_before_discount(
+        ChannelInterface $channel,
+        ProductVariantInterface $productVariant,
+    ): void {
+        $productVariant->getChannelPricingForChannel($channel)->willReturn(null);
+        $productVariant->getDescriptor()->willReturn('Red variant (RED_VARIANT)');
+
+        $this
+            ->shouldThrow(MissingChannelConfigurationException::class)
+            ->during('getLowestPriceBeforeDiscount', [$productVariant, $channel])
+        ;
+    }
+}

--- a/spec/Infrastructure/EntityListener/ChannelPricingChangeListenerSpec.php
+++ b/spec/Infrastructure/EntityListener/ChannelPricingChangeListenerSpec.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\PriceHistoryPlugin\Infrastructure\EntityListener;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
+
+final class ChannelPricingChangeListenerSpec extends ObjectBehavior
+{
+    function let(ProductLowestPriceBeforeDiscountProcessorInterface $lowestPriceProcessor): void
+    {
+        $this->beConstructedWith($lowestPriceProcessor);
+    }
+
+    function it_processes_lowest_price_for_channel_pricing(
+        ProductLowestPriceBeforeDiscountProcessorInterface $lowestPriceProcessor,
+        ChannelPricingInterface $channelPricing,
+    ): void {
+        $lowestPriceProcessor->process($channelPricing)->shouldBeCalled();
+
+        $this->postUpdate($channelPricing);
+    }
+}

--- a/spec/Infrastructure/Serializer/ProductVariantNormalizerSpec.php
+++ b/spec/Infrastructure/Serializer/ProductVariantNormalizerSpec.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\PriceHistoryPlugin\Infrastructure\Serializer;
+
+use phpDocumentor\Reflection\Types\Context;
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ApiBundle\SectionResolver\AdminApiSection;
+use Sylius\Bundle\ApiBundle\SectionResolver\ShopApiSection;
+use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
+use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
+use Sylius\Component\Core\Exception\MissingChannelConfigurationException;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\PriceHistoryPlugin\Application\Provider\ProductVariantPriceProviderInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class ProductVariantNormalizerSpec extends ObjectBehavior
+{
+    private const ALREADY_CALLED = 'sylius_price_history_product_variant_normalizer_already_called';
+
+    function let(ProductVariantPriceProviderInterface $priceProvider, SectionProviderInterface $sectionProvider): void
+    {
+        $this->beConstructedWith($priceProvider, $sectionProvider);
+    }
+
+    function it_supports_only_product_variant_interface(
+        ChannelInterface $channel,
+        OrderInterface $order,
+        ProductVariantInterface $variant,
+    ): void {
+        $this->supportsNormalization($variant, context: [ContextKeys::CHANNEL => $channel])->shouldReturn(true);
+        $this->supportsNormalization($order, context: [ContextKeys::CHANNEL => $channel])->shouldReturn(false);
+    }
+
+    function it_supports_normalization_if_section_is_shop_get(
+        SectionProviderInterface $sectionProvider,
+        ChannelInterface $channel,
+        ProductVariantInterface $variant,
+        ShopApiSection $shopApiSection,
+    ): void {
+        $sectionProvider->getSection()->willReturn($shopApiSection);
+        $this->supportsNormalization($variant, context: [ContextKeys::CHANNEL => $channel])->shouldReturn(true);
+    }
+
+    function it_does_not_support_if_section_is_admin_get(
+        SectionProviderInterface $sectionProvider,
+        AdminApiSection $adminApiSection,
+        ChannelInterface $channel,
+        ProductVariantInterface $variant,
+    ): void {
+        $sectionProvider->getSection()->willReturn($adminApiSection);
+        $this->supportsNormalization($variant, context: [ContextKeys::CHANNEL => $channel])->shouldReturn(false);
+    }
+
+    function it_does_not_support_if_the_normalizer_has_been_already_called(ProductVariantInterface $variant): void
+    {
+        $this
+            ->supportsNormalization($variant, null, [self::ALREADY_CALLED => true])
+            ->shouldReturn(false)
+        ;
+    }
+
+    function it_does_not_support_if_there_is_no_channel_in_the_context(ProductVariantInterface $variant): void
+    {
+        $this
+            ->supportsNormalization($variant)
+            ->shouldReturn(false)
+        ;
+    }
+
+    function it_adds_lowest_price_before_discount_to_variant_data(
+        ProductVariantPriceProviderInterface $priceProvider,
+        NormalizerInterface $normalizer,
+        ChannelInterface $channel,
+        ProductVariantInterface $variant,
+    ): void {
+        $this->setNormalizer($normalizer);
+
+        $context = [ContextKeys::CHANNEL => $channel];
+
+        $normalizer
+            ->normalize(
+                $variant,
+                null,
+                array_merge($context, [self::ALREADY_CALLED => true])
+            )
+            ->willReturn([])
+        ;
+
+        $priceProvider->getLowestPriceBeforeDiscount($variant, $channel)->willReturn(3700);
+
+        $this->normalize($variant, null, $context)->shouldBeLike(['lowestPriceBeforeDiscount' => 3700]);
+    }
+
+    function it_does_not_add_lowest_price_before_discount_to_variant_data_if_missing_channel_configuration_exception_is_thrown(
+        ProductVariantPriceProviderInterface $priceProvider,
+        NormalizerInterface $normalizer,
+        ChannelInterface $channel,
+        ProductVariantInterface $variant,
+    ): void {
+        $this->setNormalizer($normalizer);
+
+        $context = [ContextKeys::CHANNEL => $channel];
+
+        $normalizer
+            ->normalize(
+                $variant,
+                null,
+                array_merge($context, [self::ALREADY_CALLED => true])
+            )
+            ->willReturn([])
+        ;
+
+        $priceProvider
+            ->getLowestPriceBeforeDiscount($variant, $channel)
+            ->willThrow(MissingChannelConfigurationException::class)
+        ;
+
+        $this->normalize($variant, null, $context)->shouldBeLike([]);
+    }
+
+    function it_throws_an_exception_if_the_normalizer_has_been_already_called(
+        NormalizerInterface $normalizer,
+        ProductVariantInterface $variant,
+    ): void {
+        $this->setNormalizer($normalizer);
+
+        $normalizer->normalize($variant, null, [self::ALREADY_CALLED => true])->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('normalize', [$variant, null, [self::ALREADY_CALLED => true]])
+        ;
+    }
+
+    function it_throws_an_exception_if_there_is_no_channel_in_the_context(
+        NormalizerInterface $normalizer,
+        ProductVariantInterface $variant,
+    ): void {
+        $this->setNormalizer($normalizer);
+
+        $normalizer
+            ->normalize($variant, null, [self::ALREADY_CALLED => true])
+            ->willReturn([])
+        ;
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during(
+                'normalize',
+                [$variant, null, [self::ALREADY_CALLED => false]]
+            )
+        ;
+    }
+}

--- a/src/Application/Factory/ChannelPricingLogEntryFactory.php
+++ b/src/Application/Factory/ChannelPricingLogEntryFactory.php
@@ -17,7 +17,7 @@ use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Resource\Exception\UnsupportedMethodException;
 use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingLogEntryInterface;
 
-class ChannelPricingLogEntryFactory implements ChannelPricingLogEntryFactoryInterface
+final class ChannelPricingLogEntryFactory implements ChannelPricingLogEntryFactoryInterface
 {
     public function __construct(private string $className)
     {
@@ -43,11 +43,14 @@ class ChannelPricingLogEntryFactory implements ChannelPricingLogEntryFactoryInte
         int $price,
         ?int $originalPrice = null,
     ): ChannelPricingLogEntryInterface {
-        return new $this->className(
+        /** @var ChannelPricingLogEntryInterface $channelPricingLogEntry */
+        $channelPricingLogEntry = new $this->className(
             $channelPricing,
             $loggedAt,
             $price,
             $originalPrice,
         );
+
+        return $channelPricingLogEntry;
     }
 }

--- a/src/Application/Processor/ProductLowestPriceBeforeDiscountProcessor.php
+++ b/src/Application/Processor/ProductLowestPriceBeforeDiscountProcessor.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Application\Processor;
+
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingLogEntryInterface;
+use Sylius\PriceHistoryPlugin\Domain\Repository\ChannelPricingLogEntryRepositoryInterface;
+use Webmozart\Assert\Assert;
+
+final class ProductLowestPriceBeforeDiscountProcessor implements ProductLowestPriceBeforeDiscountProcessorInterface
+{
+    public function __construct(
+        private ChannelPricingLogEntryRepositoryInterface $channelPricingLogEntryRepository,
+        private ChannelRepositoryInterface $channelRepository,
+    ) {
+    }
+
+    public function process(ChannelPricingInterface $channelPricing): void
+    {
+        if (!$this->isPromotionApplied($channelPricing)) {
+            $channelPricing->setLowestPriceBeforeDiscount(null);
+
+            return;
+        }
+
+        $latestLogEntry = $this->channelPricingLogEntryRepository->findLatestOneByChannelPricing($channelPricing);
+
+        if ($latestLogEntry === null) {
+            $channelPricing->setLowestPriceBeforeDiscount(null);
+
+            return;
+        }
+
+        $channelCode = $channelPricing->getChannelCode();
+        Assert::string($channelCode);
+
+        /** @var ChannelInterface $channel */
+        $channel = $this->channelRepository->findOneByCode($channelCode);
+
+        $lowestPriceInPeriod = $this->findLowestPriceInPeriod(
+            $latestLogEntry,
+            $channel->getLowestPriceForDiscountedProductsCheckingPeriod(),
+        );
+
+        $channelPricing->setLowestPriceBeforeDiscount($lowestPriceInPeriod);
+    }
+
+    private function isPromotionApplied(ChannelPricingInterface $channelPricing): bool
+    {
+        return
+            $channelPricing->getOriginalPrice() !== null &&
+            $channelPricing->getPrice() < $channelPricing->getOriginalPrice()
+        ;
+    }
+
+    private function findLowestPriceInPeriod(
+        ChannelPricingLogEntryInterface $latestLogEntry,
+        int $lowestPriceForDiscountedProductsCheckingPeriod,
+    ): ?int {
+        $loggedAt = new \DateTimeImmutable($latestLogEntry->getLoggedAt()->format('Y-m-d H:i:s'));
+
+        /** @var \DateTimeInterface $startDate */
+        $startDate = $loggedAt->sub(new \DateInterval(sprintf('P%sD', $lowestPriceForDiscountedProductsCheckingPeriod)));
+
+        return $this
+            ->channelPricingLogEntryRepository
+            ->findLowestPriceInPeriod($latestLogEntry->getId(), $latestLogEntry->getChannelPricing(), $startDate)
+        ;
+    }
+}

--- a/src/Application/Processor/ProductLowestPriceBeforeDiscountProcessorInterface.php
+++ b/src/Application/Processor/ProductLowestPriceBeforeDiscountProcessorInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Application\Processor;
+
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
+
+interface ProductLowestPriceBeforeDiscountProcessorInterface
+{
+    public function process(ChannelPricingInterface $channelPricing): void;
+}

--- a/src/Application/Provider/ProductVariantPriceProvider.php
+++ b/src/Application/Provider/ProductVariantPriceProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Application\Provider;
+
+use Sylius\Component\Core\Exception\MissingChannelConfigurationException;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
+
+final class ProductVariantPriceProvider implements ProductVariantPriceProviderInterface
+{
+    public function getLowestPriceBeforeDiscount(ProductVariantInterface $productVariant, ChannelInterface $channel): ?int
+    {
+        /** @var ChannelPricingInterface|null $channelPricing */
+        $channelPricing = $productVariant->getChannelPricingForChannel($channel);
+
+        if (null === $channelPricing) {
+            throw MissingChannelConfigurationException::createForProductVariantChannelPricing($productVariant, $channel);
+        }
+
+        return $channelPricing->getLowestPriceBeforeDiscount();
+    }
+}

--- a/src/Application/Provider/ProductVariantPriceProviderInterface.php
+++ b/src/Application/Provider/ProductVariantPriceProviderInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Application\Provider;
+
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelInterface;
+
+interface ProductVariantPriceProviderInterface
+{
+    public function getLowestPriceBeforeDiscount(ProductVariantInterface $productVariant, ChannelInterface $channel): ?int;
+}

--- a/src/Domain/Model/ChannelPricingInterface.php
+++ b/src/Domain/Model/ChannelPricingInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Domain\Model;
+
+use Sylius\Component\Core\Model\ChannelPricingInterface as BaseChannelPricingInterface;
+
+interface ChannelPricingInterface extends BaseChannelPricingInterface, LowestPriceBeforeDiscountAwareInterface
+{
+}

--- a/src/Domain/Model/LowestPriceBeforeDiscountAwareInterface.php
+++ b/src/Domain/Model/LowestPriceBeforeDiscountAwareInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Domain\Model;
+
+interface LowestPriceBeforeDiscountAwareInterface
+{
+    public function getLowestPriceBeforeDiscount(): ?int;
+
+    public function setLowestPriceBeforeDiscount(?int $lowestPriceBeforeDiscount): void;
+}

--- a/src/Domain/Model/LowestPriceBeforeDiscountAwareTrait.php
+++ b/src/Domain/Model/LowestPriceBeforeDiscountAwareTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Domain\Model;
+
+use Doctrine\ORM\Mapping as ORM;
+
+trait LowestPriceBeforeDiscountAwareTrait
+{
+    /** @ORM\Column(type="integer", nullable=true) */
+    #[ORM\Column(type: 'integer', nullable: true)]
+    protected ?int $lowestPriceBeforeDiscount = null;
+
+    public function getLowestPriceBeforeDiscount(): ?int
+    {
+        return $this->lowestPriceBeforeDiscount;
+    }
+
+    public function setLowestPriceBeforeDiscount(?int $lowestPriceBeforeDiscount): void
+    {
+        $this->lowestPriceBeforeDiscount = $lowestPriceBeforeDiscount;
+    }
+}

--- a/src/Domain/Repository/ChannelPricingLogEntryRepositoryInterface.php
+++ b/src/Domain/Repository/ChannelPricingLogEntryRepositoryInterface.php
@@ -24,13 +24,11 @@ interface ChannelPricingLogEntryRepositoryInterface extends RepositoryInterface
      */
     public function findOlderThan(\DateTimeInterface $date, ?int $limit = null): array;
 
-    public function findLatestOne(ChannelPricingInterface $channelPricing): ?ChannelPricingLogEntryInterface;
+    public function findLatestOneByChannelPricing(ChannelPricingInterface $channelPricing): ?ChannelPricingLogEntryInterface;
 
     public function findLowestPriceInPeriod(
         int $channelPricingLogEntryId,
         ChannelPricingInterface $channelPricing,
         \DateTimeInterface $startDate,
     ): ?int;
-
-    public function findLatestPriceBeyondPeriod(ChannelPricingInterface $channelPricing, \DateTimeInterface $startDate): ?int;
 }

--- a/src/Domain/Repository/ChannelPricingLogEntryRepositoryInterface.php
+++ b/src/Domain/Repository/ChannelPricingLogEntryRepositoryInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\PriceHistoryPlugin\Domain\Repository;
 
+use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingLogEntryInterface;
 
@@ -22,4 +23,14 @@ interface ChannelPricingLogEntryRepositoryInterface extends RepositoryInterface
      * @return array|ChannelPricingLogEntryInterface[]
      */
     public function findOlderThan(\DateTimeInterface $date, ?int $limit = null): array;
+
+    public function findLatestOne(ChannelPricingInterface $channelPricing): ?ChannelPricingLogEntryInterface;
+
+    public function findLowestPriceInPeriod(
+        int $channelPricingLogEntryId,
+        ChannelPricingInterface $channelPricing,
+        \DateTimeInterface $startDate,
+    ): ?int;
+
+    public function findLatestPriceBeyondPeriod(ChannelPricingInterface $channelPricing, \DateTimeInterface $startDate): ?int;
 }

--- a/src/Infrastructure/EntityListener/ChannelPricingChangeListener.php
+++ b/src/Infrastructure/EntityListener/ChannelPricingChangeListener.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Infrastructure\EntityListener;
+
+use Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
+
+final class ChannelPricingChangeListener
+{
+    public function __construct(private ProductLowestPriceBeforeDiscountProcessorInterface $lowestPriceProcessor)
+    {
+    }
+
+    public function postUpdate(ChannelPricingInterface $channelPricing): void
+    {
+        $this->lowestPriceProcessor->process($channelPricing);
+    }
+}

--- a/src/Infrastructure/Migrations/Version20230206081319.php
+++ b/src/Infrastructure/Migrations/Version20230206081319.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Infrastructure\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230206081319 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add ChannelPricing::lowestPriceBeforeDiscount';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_channel_pricing ADD lowestPriceBeforeDiscount INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_channel_pricing DROP lowestPriceBeforeDiscount');
+    }
+}

--- a/src/Infrastructure/Serializer/ProductVariantNormalizer.php
+++ b/src/Infrastructure/Serializer/ProductVariantNormalizer.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Infrastructure\Serializer;
+
+use Sylius\Bundle\ApiBundle\SectionResolver\AdminApiSection;
+use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
+use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
+use Sylius\Component\Core\Exception\MissingChannelConfigurationException;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\PriceHistoryPlugin\Application\Provider\ProductVariantPriceProviderInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Webmozart\Assert\Assert;
+
+final class ProductVariantNormalizer implements NormalizerInterface, NormalizerAwareInterface
+{
+    use NormalizerAwareTrait;
+
+    private const ALREADY_CALLED = 'sylius_price_history_product_variant_normalizer_already_called';
+
+    public function __construct(
+        private ProductVariantPriceProviderInterface $priceProvider,
+        private SectionProviderInterface $uriBasedSectionContext,
+    ) {
+    }
+
+    public function normalize(mixed $object, string $format = null, array $context = [])
+    {
+        Assert::isInstanceOf($object, ProductVariantInterface::class);
+        Assert::keyNotExists($context, self::ALREADY_CALLED);
+
+        $context[self::ALREADY_CALLED] = true;
+        $data = $this->normalizer->normalize($object, $format, $context);
+        Assert::isArray($data);
+
+        /** @var ChannelInterface $channel */
+        $channel = $context[ContextKeys::CHANNEL];
+
+        try {
+            $data['lowestPriceBeforeDiscount'] = $this->priceProvider->getLowestPriceBeforeDiscount($object, $channel);
+        } catch (MissingChannelConfigurationException) {
+        }
+
+        return $data;
+    }
+
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    {
+        if (isset($context[self::ALREADY_CALLED]) || !array_key_exists(ContextKeys::CHANNEL, $context)) {
+            return false;
+        }
+
+        return $data instanceof ProductVariantInterface && $this->isNotAdminApiSection();
+    }
+
+    private function isNotAdminApiSection(): bool
+    {
+        return !$this->uriBasedSectionContext->getSection() instanceof AdminApiSection;
+    }
+}

--- a/tests/Api/Admin/ChannelPricingLogEntryTest.php
+++ b/tests/Api/Admin/ChannelPricingLogEntryTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\PriceHistoryPlugin\Api\Admin;
 
-use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
 use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingLogEntryInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Sylius\PriceHistoryPlugin\Api\JsonApiTestCase;

--- a/tests/Api/DataFixtures/ORM/product_variant_with_no_prices.yaml
+++ b/tests/Api/DataFixtures/ORM/product_variant_with_no_prices.yaml
@@ -10,17 +10,6 @@ Tests\Sylius\PriceHistoryPlugin\Application\Entity\Channel:
         color: 'black'
         enabled: true
         taxCalculationStrategy: 'order_items_based'
-    channel_fashion:
-        code: 'FASHION'
-        name: 'Fashion Channel'
-        hostname: 'fashion.localhost'
-        description: 'Lorem ipsum'
-        baseCurrency: '@currency_usd'
-        defaultLocale: '@locale_en'
-        locales: ['@locale_en', '@locale_pl']
-        color: 'black'
-        enabled: true
-        taxCalculationStrategy: 'order_items_based'
 
 Sylius\Component\Currency\Model\Currency:
     currency_usd:
@@ -37,7 +26,7 @@ Sylius\Component\Locale\Model\Locale:
 Sylius\Component\Core\Model\Product:
     product_mug:
         code: 'MUG'
-        channels: ['@channel_home', '@channel_fashion']
+        channels: ['@channel_home']
         currentLocale: 'en_US'
         translations:
             en_US: '@product_translation_mug'
@@ -57,9 +46,6 @@ Sylius\Component\Core\Model\ProductVariant:
         currentLocale: 'en_US'
         translations:
             en_US: '@product_variant_translation_mug_blue'
-        channelPricings:
-            HOME: '@channel_pricing_product_variant_mug_blue_home'
-            FASHION: '@channel_pricing_product_variant_mug_blue_fashion'
     
     product_variant_mug_red:
         code: 'MUG_RED'
@@ -67,9 +53,6 @@ Sylius\Component\Core\Model\ProductVariant:
         currentLocale: 'en_US'
         translations:
             en_US: '@product_variant_translation_mug_red'
-        channelPricings:
-            HOME: '@channel_pricing_product_variant_mug_red_home'
-            FASHION: '@channel_pricing_product_variant_mug_red_fashion'
 
 Sylius\Component\Product\Model\ProductVariantTranslation:
     product_variant_translation_mug_blue:
@@ -80,19 +63,3 @@ Sylius\Component\Product\Model\ProductVariantTranslation:
         locale: 'en_US'
         name: 'Red Mug'
         translatable: '@product_variant_mug_red'
-
-Tests\Sylius\PriceHistoryPlugin\Application\Entity\ChannelPricing:
-    channel_pricing_product_variant_mug_blue_home:
-        channelCode: 'HOME'
-        price: 1000
-        originalPrice: 2000
-        lowestPriceBeforeDiscount: 2100
-    channel_pricing_product_variant_mug_blue_fashion:
-        channelCode: 'FASHION'
-        price: 2000
-    channel_pricing_product_variant_mug_red_home:
-        channelCode: 'HOME'
-        price: 3000
-    channel_pricing_product_variant_mug_red_fashion:
-        channelCode: 'FASHION'
-        price: 3000

--- a/tests/Api/DataFixtures/ORM/product_variant_without_discount.yaml
+++ b/tests/Api/DataFixtures/ORM/product_variant_without_discount.yaml
@@ -10,17 +10,6 @@ Tests\Sylius\PriceHistoryPlugin\Application\Entity\Channel:
         color: 'black'
         enabled: true
         taxCalculationStrategy: 'order_items_based'
-    channel_fashion:
-        code: 'FASHION'
-        name: 'Fashion Channel'
-        hostname: 'fashion.localhost'
-        description: 'Lorem ipsum'
-        baseCurrency: '@currency_usd'
-        defaultLocale: '@locale_en'
-        locales: ['@locale_en', '@locale_pl']
-        color: 'black'
-        enabled: true
-        taxCalculationStrategy: 'order_items_based'
 
 Sylius\Component\Currency\Model\Currency:
     currency_usd:
@@ -37,7 +26,7 @@ Sylius\Component\Locale\Model\Locale:
 Sylius\Component\Core\Model\Product:
     product_mug:
         code: 'MUG'
-        channels: ['@channel_home', '@channel_fashion']
+        channels: ['@channel_home']
         currentLocale: 'en_US'
         translations:
             en_US: '@product_translation_mug'
@@ -59,40 +48,15 @@ Sylius\Component\Core\Model\ProductVariant:
             en_US: '@product_variant_translation_mug_blue'
         channelPricings:
             HOME: '@channel_pricing_product_variant_mug_blue_home'
-            FASHION: '@channel_pricing_product_variant_mug_blue_fashion'
-    
-    product_variant_mug_red:
-        code: 'MUG_RED'
-        product: '@product_mug'
-        currentLocale: 'en_US'
-        translations:
-            en_US: '@product_variant_translation_mug_red'
-        channelPricings:
-            HOME: '@channel_pricing_product_variant_mug_red_home'
-            FASHION: '@channel_pricing_product_variant_mug_red_fashion'
 
 Sylius\Component\Product\Model\ProductVariantTranslation:
     product_variant_translation_mug_blue:
         locale: 'en_US'
         name: 'Blue Mug'
         translatable: '@product_variant_mug_blue'
-    product_variant_translation_mug_red:
-        locale: 'en_US'
-        name: 'Red Mug'
-        translatable: '@product_variant_mug_red'
 
 Tests\Sylius\PriceHistoryPlugin\Application\Entity\ChannelPricing:
     channel_pricing_product_variant_mug_blue_home:
         channelCode: 'HOME'
         price: 1000
         originalPrice: 2000
-        lowestPriceBeforeDiscount: 2100
-    channel_pricing_product_variant_mug_blue_fashion:
-        channelCode: 'FASHION'
-        price: 2000
-    channel_pricing_product_variant_mug_red_home:
-        channelCode: 'HOME'
-        price: 3000
-    channel_pricing_product_variant_mug_red_fashion:
-        channelCode: 'FASHION'
-        price: 3000

--- a/tests/Api/Responses/shop/product/get_product_variant_with_discount_response.json
+++ b/tests/Api/Responses/shop/product/get_product_variant_with_discount_response.json
@@ -1,0 +1,14 @@
+{
+    "@context": "\/api\/v2\/contexts\/ProductVariant",
+    "@id": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+    "@type": "ProductVariant",
+    "id": @integer@,
+    "code": "MUG_BLUE",
+    "name": "Blue Mug",
+    "product": "\/api\/v2\/shop\/products\/MUG",
+    "optionValues": [],
+    "price": 1000,
+    "originalPrice": 2000,
+    "inStock": true,
+    "lowestPriceBeforeDiscount": 2100
+}

--- a/tests/Api/Responses/shop/product/get_product_variant_with_no_prices.json
+++ b/tests/Api/Responses/shop/product/get_product_variant_with_no_prices.json
@@ -1,0 +1,11 @@
+{
+    "@context": "\/api\/v2\/contexts\/ProductVariant",
+    "@id": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+    "@type": "ProductVariant",
+    "id": @integer@,
+    "code": "MUG_BLUE",
+    "name": "Blue Mug",
+    "product": "\/api\/v2\/shop\/products\/MUG",
+    "optionValues": [],
+    "inStock": true
+}

--- a/tests/Api/Responses/shop/product/get_product_variant_without_discount_response.json
+++ b/tests/Api/Responses/shop/product/get_product_variant_without_discount_response.json
@@ -1,0 +1,14 @@
+{
+    "@context": "\/api\/v2\/contexts\/ProductVariant",
+    "@id": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+    "@type": "ProductVariant",
+    "id": @integer@,
+    "code": "MUG_BLUE",
+    "name": "Blue Mug",
+    "product": "\/api\/v2\/shop\/products\/MUG",
+    "optionValues": [],
+    "price": 1000,
+    "originalPrice": 2000,
+    "inStock": true,
+    "lowestPriceBeforeDiscount": null
+}

--- a/tests/Api/Shop/ProductVariantsTest.php
+++ b/tests/Api/Shop/ProductVariantsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PriceHistoryPlugin\Api\Shop;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Sylius\PriceHistoryPlugin\Api\JsonApiTestCase;
+
+final class ProductVariantsTest extends JsonApiTestCase
+{
+    /** @test */
+    public function it_gets_product_variant_with_discount(): void
+    {
+        $this->loadFixturesFromFile('product_variant.yaml');
+
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/shop/product-variants/MUG_BLUE',
+            parameters: ['_channel_code' => 'HOME'],
+            server: $this->getUnloggedHeader()
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'shop/product/get_product_variant_with_discount_response',
+            Response::HTTP_OK,
+        );
+    }
+
+    /** @test */
+    public function it_gets_product_variant_without_discount(): void
+    {
+        $this->loadFixturesFromFile('product_variant_without_discount.yaml');
+
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/shop/product-variants/MUG_BLUE',
+            parameters: ['_channel_code' => 'HOME'],
+            server: $this->getUnloggedHeader()
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'shop/product/get_product_variant_without_discount_response',
+            Response::HTTP_OK,
+        );
+    }
+
+    /** @test */
+    public function it_gets_product_variant_with_no_prices(): void
+    {
+        $this->loadFixturesFromFile('product_variant_with_no_prices.yaml');
+
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/shop/product-variants/MUG_BLUE',
+            parameters: ['_channel_code' => 'HOME'],
+            server: $this->getUnloggedHeader()
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'shop/product/get_product_variant_with_no_prices',
+            Response::HTTP_OK,
+        );
+    }
+}

--- a/tests/Application/config/packages/_sylius.yaml
+++ b/tests/Application/config/packages/_sylius.yaml
@@ -21,3 +21,9 @@ sylius_channel:
         channel:
             classes:
                 model: Tests\Sylius\PriceHistoryPlugin\Application\Entity\Channel
+
+sylius_core:
+    resources:
+        channel_pricing:
+            classes:
+                model: Tests\Sylius\PriceHistoryPlugin\Application\Entity\ChannelPricing

--- a/tests/Application/src/Entity/ChannelPricing.php
+++ b/tests/Application/src/Entity/ChannelPricing.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PriceHistoryPlugin\Application\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Sylius\Component\Core\Model\ChannelPricing as BaseChannelPricing;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\LowestPriceBeforeDiscountAwareTrait;
+
+#[ORM\Table(name: 'sylius_channel_pricing')]
+#[ORM\Entity]
+class ChannelPricing extends BaseChannelPricing implements ChannelPricingInterface
+{
+    use LowestPriceBeforeDiscountAwareTrait;
+}


### PR DESCRIPTION
This PR introduces the recalculation of the field `lowestPriceBeforeDiscount` of a `ChannelPricing` entity on each product price change

It also includes the serialization of a new field in the API response:
<img width="538" alt="image" src="https://user-images.githubusercontent.com/40125720/218469689-6fb43da8-9724-4d49-b0fa-8dee027ff3a8.png">

- [ ]  To consider in the upcoming PR:
1) https://github.com/Sylius/PriceHistoryPlugin/pull/32#discussion_r1109797507
2) https://github.com/Sylius/PriceHistoryPlugin/pull/32#discussion_r1109802886

- [ ] To add:
1) https://github.com/Sylius/PriceHistoryPlugin/pull/32#pullrequestreview-1303100427

- [ ] To fix:
1) Calculating `lowestPriceBeforeDiscount` when used with catalog promotions