### PR TITLE
Fix the lowest price on a product that has the lowest price set beyond the checking period but it is still the lowest price in this period

### DIFF
--- a/features/product/viewing_products/seeing_products_lowest_price_before_the_discount.feature
+++ b/features/product/viewing_products/seeing_products_lowest_price_before_the_discount.feature
@@ -63,6 +63,18 @@ Feature: Seeing the product's lowest price before the discount
         Then I should see "$42.00" as its lowest price before the discount
 
     @api @ui
+    Scenario: Seeing the lowest price information on a product that has the lowest price set beyond the period but it is still the lowest price in the period
+        Given it is "2023-01-01" now
+        And the store has a product "Wyborowa Vodka" priced at "$10.00"
+        And on "2023-01-05" its price changed to "$9.00"
+        And on "2023-02-05" its price changed to "$11.00"
+        And on "2023-02-15" its price changed to "$13.00" and original price to "$10.00"
+        And on "2023-02-25" its price changed to "$15.00" and original price to "$20.00"
+        And it is "2023-03-01" now
+        When I check this product's details
+        Then I should see "$9.00" as its lowest price before the discount
+
+    @api @ui
     Scenario: Not seeing the lowest price information on a product that had a discount and the discount was removed
         Given the store has a product "Wyborowa Vodka" priced at "$37.00"
         And this product's price changed to "$21.00" and original price changed to "$37.00"

--- a/src/Domain/Repository/ChannelPricingLogEntryRepositoryInterface.php
+++ b/src/Domain/Repository/ChannelPricingLogEntryRepositoryInterface.php
@@ -27,7 +27,7 @@ interface ChannelPricingLogEntryRepositoryInterface extends RepositoryInterface
     public function findLatestOneByChannelPricing(ChannelPricingInterface $channelPricing): ?ChannelPricingLogEntryInterface;
 
     public function findLowestPriceInPeriod(
-        int $channelPricingLogEntryId,
+        int $latestChannelPricingLogEntryId,
         ChannelPricingInterface $channelPricing,
         \DateTimeInterface $startDate,
     ): ?int;

--- a/tests/Behat/Context/Setup/ProductContext.php
+++ b/tests/Behat/Context/Setup/ProductContext.php
@@ -129,59 +129,6 @@ final class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^on "([^"]+)" (its) price changed to ("[^"]+")$/
-     */
-    public function onDayItsPriceChangedTo(string $date, ProductInterface $product, int $price): void
-    {
-        $channelPricing = $this->getChannelPricingFromProduct($product);
-
-        $this->calendarContext->itIsNow($date);
-        $channelPricing->setPrice($price);
-
-        $this->productVariantManager->flush();
-    }
-
-    /**
-     * @Given /^on "([^"]+)" (its) original price changed to ("[^"]+")$/
-     */
-    public function onDayItsOriginalPriceChangedTo(string $date, ProductInterface $product, int $originalPrice): void
-    {
-        $channelPricing = $this->getChannelPricingFromProduct($product);
-
-        $this->calendarContext->itIsNow($date);
-        $channelPricing->setOriginalPrice($originalPrice);
-
-        $this->productVariantManager->flush();
-    }
-
-    /**
-     * @Given /^on "([^"]+)" (its) price changed to ("[^"]+") and original price to ("[^"]+")$/
-     */
-    public function onDayItsOriginalPriceChangedToAndOriginalPriceTo(string $date, ProductInterface $product, int $price, int $originalPrice): void
-    {
-        $channelPricing = $this->getChannelPricingFromProduct($product);
-
-        $this->calendarContext->itIsNow($date);
-        $channelPricing->setPrice($price);
-        $channelPricing->setOriginalPrice($originalPrice);
-
-        $this->productVariantManager->flush();
-    }
-
-    /**
-     * @Given /^on "([^"]+)" (its) original price has been removed$/
-     */
-    public function onDayItsOriginalPriceHasBeenRemoved(string $date, ProductInterface $product): void
-    {
-        $channelPricing = $this->getChannelPricingFromProduct($product);
-
-        $this->calendarContext->itIsNow($date);
-        $channelPricing->setOriginalPrice(null);
-
-        $this->productVariantManager->flush();
-    }
-
     private function getChannelPricingFromProduct(ProductInterface $product): ChannelPricingInterface
     {
         $variant = $this->defaultVariantResolver->getVariant($product);

--- a/tests/Behat/Resources/suites/api/product/viewing_products.yaml
+++ b/tests/Behat/Resources/suites/api/product/viewing_products.yaml
@@ -20,6 +20,7 @@ default:
                 - Sylius\Calendar\Tests\Behat\Context\Setup\CalendarContext
                 - Tests\Sylius\PriceHistoryPlugin\Behat\Context\Setup\CatalogPromotionContext
                 - Tests\Sylius\PriceHistoryPlugin\Behat\Context\Setup\ChannelContext
+                - Tests\Sylius\PriceHistoryPlugin\Behat\Context\Setup\PriceHistoryContext
                 - Tests\Sylius\PriceHistoryPlugin\Behat\Context\Setup\ProductContext
 
                 - sylius.behat.context.api.shop.channel

--- a/tests/Behat/Resources/suites/ui/product/viewing_products.yaml
+++ b/tests/Behat/Resources/suites/ui/product/viewing_products.yaml
@@ -20,6 +20,7 @@ default:
                 - Sylius\Calendar\Tests\Behat\Context\Setup\CalendarContext
                 - Tests\Sylius\PriceHistoryPlugin\Behat\Context\Setup\CatalogPromotionContext
                 - Tests\Sylius\PriceHistoryPlugin\Behat\Context\Setup\ChannelContext
+                - Tests\Sylius\PriceHistoryPlugin\Behat\Context\Setup\PriceHistoryContext
                 - Tests\Sylius\PriceHistoryPlugin\Behat\Context\Setup\ProductContext
 
                 - sylius.behat.context.ui.shop.product


### PR DESCRIPTION
The issue has been found in https://github.com/Sylius/PriceHistoryPlugin/pull/50#discussion_r1116884844

Explanation below:
![image](https://user-images.githubusercontent.com/13316080/221248723-5e46222a-47cb-4b4c-b15b-bee73b2e1a64.png)