### PR TITLE
[UI][Product] Improvements to displaying the lowest price before the discount

### DIFF
--- a/config/admin_routing.yaml
+++ b/config/admin_routing.yaml
@@ -15,3 +15,13 @@ sylius_price_history_admin_channel_pricing_log_entry_index:
                 header: sylius_price_history.ui.channel_pricing_history
                 subheader: sylius_price_history.ui.show_history_for_channel_pricing
                 product_variant: "expr:service('sylius.repository.product_variant').find($variantId)"
+
+sylius_admin_product_show:
+    path: /products/{id}
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.product::showAction
+        _sylius:
+            section: admin
+            permission: true
+            template: "@SyliusPriceHistoryPlugin/Admin/Product/show.html.twig"

--- a/templates/Admin/Product/Show/_simpleProduct.html.twig
+++ b/templates/Admin/Product/Show/_simpleProduct.html.twig
@@ -1,12 +1,12 @@
 {% include '@SyliusAdmin/Product/Show/_header.html.twig' %}
 
 <div class="ui grid">
-    <div class="sixteen wide mobile ten wide computer column">
+    <div class="sixteen wide mobile eight wide computer column">
         {{ sylius_template_event('sylius.admin.simple_product.show.details', _context) }}
         <div class="ui hidden divider"></div>
         {{ sylius_template_event('sylius.admin.simple_product.show.taxonomy', _context) }}
     </div>
-    <div class="sixteen wide mobile six wide computer column">
+    <div class="sixteen wide mobile eight wide computer column">
         {{ sylius_template_event('sylius.admin.simple_product.show.pricing', _context) }}
         <div class="ui hidden divider"></div>
         {{ sylius_template_event('sylius.admin.simple_product.show.shipping', _context) }}

--- a/templates/Admin/Product/Show/_simpleProduct.html.twig
+++ b/templates/Admin/Product/Show/_simpleProduct.html.twig
@@ -1,0 +1,29 @@
+{% include '@SyliusAdmin/Product/Show/_header.html.twig' %}
+
+<div class="ui grid">
+    <div class="sixteen wide mobile ten wide computer column">
+        {{ sylius_template_event('sylius.admin.simple_product.show.details', _context) }}
+        <div class="ui hidden divider"></div>
+        {{ sylius_template_event('sylius.admin.simple_product.show.taxonomy', _context) }}
+    </div>
+    <div class="sixteen wide mobile six wide computer column">
+        {{ sylius_template_event('sylius.admin.simple_product.show.pricing', _context) }}
+        <div class="ui hidden divider"></div>
+        {{ sylius_template_event('sylius.admin.simple_product.show.shipping', _context) }}
+    </div>
+</div>
+<div class="ui hidden divider"></div>
+{{ sylius_template_event('sylius.admin.simple_product.show.media', _context) }}
+
+<div class="ui hidden divider"></div>
+{{ sylius_template_event('sylius.admin.simple_product.show.more_details', _context) }}
+
+<div class="ui hidden divider"></div>
+<div class="ui grid">
+    <div class="sixteen wide mobile ten wide computer column">
+        {{ sylius_template_event('sylius.admin.simple_product.show.attributes', _context) }}
+    </div>
+    <div class="sixteen wide mobile six wide computer column">
+        {{ sylius_template_event('sylius.admin.simple_product.show.associations', _context) }}
+    </div>
+</div>

--- a/templates/Admin/Product/Show/_variantContentPricing.html.twig
+++ b/templates/Admin/Product/Show/_variantContentPricing.html.twig
@@ -11,7 +11,7 @@
                 <td class="gray text"><strong>{{ 'sylius.ui.channels'|trans }}</strong></td>
                 <td class="gray text"><strong>{{ 'sylius.ui.price'|trans }}</strong></td>
                 <td class="gray text"><strong>{{ 'sylius.ui.original_price'|trans }}</strong></td>
-                <th><strong class="gray text">{{ 'sylius_price_history.ui.the_lowest_price_before_the_discount'|trans }}</strong></th>
+                <td class="gray text"><strong>{{ 'sylius_price_history.ui.the_lowest_price_before_the_discount'|trans }}</strong></td>
                 {% if is_sylius_equal_or_above_version(11200) %}
                     <td class="gray text"><strong>{{ 'sylius.ui.discounted_by'|trans }}</strong></td>
                 {% endif %}

--- a/templates/Admin/Product/show.html.twig
+++ b/templates/Admin/Product/show.html.twig
@@ -1,0 +1,11 @@
+{% extends '@SyliusAdmin/layout.html.twig' %}
+
+{% block title %}{{ 'sylius.ui.show_product'|trans }} | {{ product.name }}{% endblock %}
+
+{% block content %}
+    {% if product.variants|length == 1 %}
+        {% include "@SyliusAdmin/Product/Show/_simpleProduct.html.twig" %}
+    {% else %}
+        {% include "@SyliusAdmin/Product/Show/_configurableProduct.html.twig" %}
+    {% endif %}
+{% endblock %}

--- a/templates/Admin/Product/show.html.twig
+++ b/templates/Admin/Product/show.html.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
     {% if product.variants|length == 1 %}
-        {% include "@SyliusAdmin/Product/Show/_simpleProduct.html.twig" %}
+        {% include "@SyliusPriceHistoryPlugin/Admin/Product/Show/_simpleProduct.html.twig" %}
     {% else %}
         {% include "@SyliusAdmin/Product/Show/_configurableProduct.html.twig" %}
     {% endif %}

--- a/traditional-installation-guide.md
+++ b/traditional-installation-guide.md
@@ -1,4 +1,3 @@
-
 Traditional installation
 ------------------------
 

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -11,4 +11,4 @@ sylius_price_history:
         days: 'Days'
         price_history: 'Price history'
         show_history_for_channel_pricing: 'Show history for channel pricing'
-        the_lowest_price_before_the_discount: 'The lowest price before the discount'
+        the_lowest_price_before_the_discount: 'Lowest price before discount'


### PR DESCRIPTION
The continuation of: https://github.com/Sylius/PriceHistoryPlugin/pull/52

Simple product:
<img width="1442" alt="image" src="https://user-images.githubusercontent.com/40125720/222753079-e61ea9fa-89ed-4228-8570-a167ec97023a.png">
Configurable product:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/40125720/222753293-259ec7e6-b0ab-4dca-9e7c-946a4f54672f.png">
