### PR TITLE
[POC] Improve `ProductLowestPriceBeforeDiscountProcessor`

### DIFF
--- a/config/services/listeners.xml
+++ b/config/services/listeners.xml
@@ -22,9 +22,7 @@
         </service>
 
         <service id="Sylius\PriceHistoryPlugin\Infrastructure\EntityObserver\ProcessLowestPriceOnCheckingPeriodChangeObserver">
-            <argument type="service" id="Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface" />
-            <argument type="service" id="sylius.repository.channel_pricing" />
-            <argument>%sylius_price_history.batch_size%</argument>
+            <argument type="service" id="sylius_price_history.repository.channel_pricing_log_entry" />
             <tag name="sylius_price_history.entity_observer" />
         </service>
 

--- a/spec/Application/Processor/ProductLowestPriceBeforeDiscountProcessorSpec.php
+++ b/spec/Application/Processor/ProductLowestPriceBeforeDiscountProcessorSpec.php
@@ -45,12 +45,10 @@ final class ProductLowestPriceBeforeDiscountProcessorSpec extends ObjectBehavior
         $channelPricing->getOriginalPrice()->willReturn(null);
         $channelPricing->getPrice()->willReturn(2100);
 
-        $channelRepository->findOneByCode(Argument::any())->shouldNotBeCalled();
-        $channelPricingLogEntryRepository->findLatestOneByChannelPricing($channelPricing)->shouldNotBeCalled();
-        $channelPricingLogEntryRepository->findLowestPriceInPeriod(Argument::cetera())->shouldNotBeCalled();
-
-        $channelPricing->getChannelCode()->shouldNotBeCalled();
         $channelPricing->setLowestPriceBeforeDiscount(null)->shouldBeCalled();
+        $channelPricing->getChannelCode()->shouldNotBeCalled();
+        $channelRepository->findOneByCode(Argument::any())->shouldNotBeCalled();
+        $channelPricingLogEntryRepository->findLowestPricesBeforeDiscount($channelPricing)->shouldNotBeCalled();
 
         $this->process($channelPricing);
     }
@@ -63,12 +61,10 @@ final class ProductLowestPriceBeforeDiscountProcessorSpec extends ObjectBehavior
         $channelPricing->getOriginalPrice()->willReturn(2100);
         $channelPricing->getPrice()->willReturn(2100);
 
-        $channelRepository->findOneByCode(Argument::any())->shouldNotBeCalled();
-        $channelPricingLogEntryRepository->findLatestOneByChannelPricing($channelPricing)->shouldNotBeCalled();
-        $channelPricingLogEntryRepository->findLowestPriceInPeriod(Argument::cetera())->shouldNotBeCalled();
-
-        $channelPricing->getChannelCode()->shouldNotBeCalled();
         $channelPricing->setLowestPriceBeforeDiscount(null)->shouldBeCalled();
+        $channelPricing->getChannelCode()->shouldNotBeCalled();
+        $channelRepository->findOneByCode(Argument::any())->shouldNotBeCalled();
+        $channelPricingLogEntryRepository->findLowestPricesBeforeDiscount($channelPricing)->shouldNotBeCalled();
 
         $this->process($channelPricing);
     }
@@ -81,12 +77,10 @@ final class ProductLowestPriceBeforeDiscountProcessorSpec extends ObjectBehavior
         $channelPricing->getOriginalPrice()->willReturn(2100);
         $channelPricing->getPrice()->willReturn(3700);
 
-        $channelRepository->findOneByCode(Argument::any())->shouldNotBeCalled();
-        $channelPricingLogEntryRepository->findLatestOneByChannelPricing($channelPricing)->shouldNotBeCalled();
-        $channelPricingLogEntryRepository->findLowestPriceInPeriod(Argument::cetera())->shouldNotBeCalled();
-
-        $channelPricing->getChannelCode()->shouldNotBeCalled();
         $channelPricing->setLowestPriceBeforeDiscount(null)->shouldBeCalled();
+        $channelPricing->getChannelCode()->shouldNotBeCalled();
+        $channelRepository->findOneByCode(Argument::any())->shouldNotBeCalled();
+        $channelPricingLogEntryRepository->findLowestPricesBeforeDiscount($channelPricing)->shouldNotBeCalled();
 
         $this->process($channelPricing);
     }
@@ -100,11 +94,10 @@ final class ProductLowestPriceBeforeDiscountProcessorSpec extends ObjectBehavior
         $channelPricing->getOriginalPrice()->willReturn(3700);
         $channelPricing->getPrice()->willReturn(2100);
         $channelPricing->getChannelCode()->willReturn('WEB');
-        $channel->getLowestPriceForDiscountedProductsCheckingPeriod()->shouldNotBeCalled();
-
         $channelRepository->findOneByCode('WEB')->willReturn($channel);
-        $channelPricingLogEntryRepository->findLatestOneByChannelPricing($channelPricing)->willReturn(null);
-        $channelPricingLogEntryRepository->findLowestPriceInPeriod(Argument::cetera())->shouldNotBeCalled();
+        $channel->getLowestPriceForDiscountedProductsCheckingPeriod()->willReturn(30);
+
+        $channelPricingLogEntryRepository->findLowestPricesBeforeDiscount($channelPricing, 30)->willReturn(null);
 
         $channelPricing->setLowestPriceBeforeDiscount(null)->shouldBeCalled();
 
@@ -116,29 +109,14 @@ final class ProductLowestPriceBeforeDiscountProcessorSpec extends ObjectBehavior
         ChannelRepositoryInterface $channelRepository,
         ChannelInterface $channel,
         ChannelPricingInterface $channelPricing,
-        ChannelPricingLogEntry $latestLogEntry,
     ): void {
         $channelPricing->getOriginalPrice()->willReturn(3700);
         $channelPricing->getPrice()->willReturn(2100);
         $channelPricing->getChannelCode()->willReturn('WEB');
-
         $channelRepository->findOneByCode('WEB')->willReturn($channel);
         $channel->getLowestPriceForDiscountedProductsCheckingPeriod()->willReturn(30);
 
-        $unformattedDate = new \DateTimeImmutable();
-        $latestLogEntry->getLoggedAt()->willReturn($unformattedDate);
-        $loggedAt = new \DateTimeImmutable($unformattedDate->format('Y-m-d H:i:s'));
-        $startDate = $loggedAt->sub(new \DateInterval(sprintf('P%dD', 30)));
-
-        $latestLogEntry->getChannelPricing()->willReturn($channelPricing);
-        $latestLogEntry->getLoggedAt()->willReturn($loggedAt);
-        $latestLogEntry->getId()->willReturn(1234);
-
-        $channelPricingLogEntryRepository->findLatestOneByChannelPricing($channelPricing)->willReturn($latestLogEntry);
-        $channelPricingLogEntryRepository
-            ->findLowestPriceInPeriod(1234, $channelPricing, $startDate)
-            ->willReturn(6900)
-        ;
+        $channelPricingLogEntryRepository->findLowestPricesBeforeDiscount($channelPricing, 30)->willReturn(6900);
 
         $channelPricing->setLowestPriceBeforeDiscount(6900)->shouldBeCalled();
 

--- a/src/Domain/Repository/ChannelPricingLogEntryRepositoryInterface.php
+++ b/src/Domain/Repository/ChannelPricingLogEntryRepositoryInterface.php
@@ -15,6 +15,7 @@ namespace Sylius\PriceHistoryPlugin\Domain\Repository;
 
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelInterface;
 use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingLogEntryInterface;
 
 interface ChannelPricingLogEntryRepositoryInterface extends RepositoryInterface
@@ -24,11 +25,10 @@ interface ChannelPricingLogEntryRepositoryInterface extends RepositoryInterface
      */
     public function findOlderThan(\DateTimeInterface $date, ?int $limit = null): array;
 
-    public function findLatestOneByChannelPricing(ChannelPricingInterface $channelPricing): ?ChannelPricingLogEntryInterface;
+    public function bulkUpdateLowestPricesBeforeDiscount(ChannelInterface $channel): void;
 
-    public function findLowestPriceInPeriod(
-        int $latestChannelPricingLogEntryId,
+    public function findLowestPricesBeforeDiscount(
         ChannelPricingInterface $channelPricing,
-        \DateTimeInterface $startDate,
+        int $lowestPriceForDiscountedProductsCheckingPeriod,
     ): ?int;
 }

--- a/src/Infrastructure/Doctrine/ORM/ChannelPricingLogEntryRepository.php
+++ b/src/Infrastructure/Doctrine/ORM/ChannelPricingLogEntryRepository.php
@@ -51,7 +51,7 @@ class ChannelPricingLogEntryRepository extends EntityRepository implements Chann
         $conn = $this->getEntityManager()->getConnection();
 
         $sql = sprintf(
-            'UPDATE sylius_channel_pricing scp SET scp.lowestPriceBeforeDiscount = (%s) WHERE scp.channel_code = :channelCode',
+            'UPDATE sylius_channel_pricing scp SET scp.lowest_price_before_discount = (%s) WHERE scp.channel_code = :channelCode',
             $this->getLowestPricesBeforeDiscountQuery(),
         );
 


### PR DESCRIPTION
**This PR is a proof of concept only!**

Goals:
- [x] Process many in `ProcessLowestPriceOnCheckingPeriodChangeObserver` with minimum memory usage and execution time.
- [x] Find the lowest prices before discount for a ChannelPricing with a single query.

TODO:
- [ ] Support MySQL 5.7
- [ ] Support PostgreSQL
- [ ] Refactor
- [ ] Rewrite query into DQL (some parts could be done with query builder)