### PR TITLE
Reprocess lowest prices asynchronously

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,3 +4,10 @@
 imports:
     - { resource: '@SyliusPriceHistoryPlugin/config/events.yaml' }
     - { resource: '@SyliusPriceHistoryPlugin/config/grids/*' }
+        
+framework:
+    messenger:
+        buses:
+            sylius.no_transaction_command_bus:
+                middleware:
+                    - 'validation'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,10 +4,8 @@
 imports:
     - { resource: '@SyliusPriceHistoryPlugin/config/events.yaml' }
     - { resource: '@SyliusPriceHistoryPlugin/config/grids/*' }
-        
+
 framework:
     messenger:
-        buses:
-            sylius.no_transaction_command_bus:
-                middleware:
-                    - 'validation'
+        routing:
+            Sylius\PriceHistoryPlugin\Application\Command\ApplyLowestPriceOnChannelPricings: main

--- a/config/services/command_dispatchers.xml
+++ b/config/services/command_dispatchers.xml
@@ -20,7 +20,7 @@
             class="Sylius\PriceHistoryPlugin\Application\CommandDispatcher\BatchedApplyLowestPriceOnChannelPricingsCommandDispatcher"
         >
             <argument type="service" id="sylius.repository.channel_pricing" />
-            <argument type="service" id="sylius.command_bus" />
+            <argument type="service" id="sylius.no_transaction_command_bus" />
             <argument>%sylius_price_history.batch_size%</argument>
         </service>
     </services>

--- a/config/services/command_dispatchers.xml
+++ b/config/services/command_dispatchers.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="true" />
+
+        <service
+            id="Sylius\PriceHistoryPlugin\Application\CommandDispatcher\ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface"
+            class="Sylius\PriceHistoryPlugin\Application\CommandDispatcher\BatchedApplyLowestPriceOnChannelPricingsCommandDispatcher"
+        >
+            <argument type="service" id="sylius.repository.channel_pricing" />
+            <argument type="service" id="sylius.command_bus" />
+            <argument>%sylius_price_history.batch_size%</argument>
+        </service>
+    </services>
+</container>

--- a/config/services/command_dispatchers.xml
+++ b/config/services/command_dispatchers.xml
@@ -20,7 +20,7 @@
             class="Sylius\PriceHistoryPlugin\Application\CommandDispatcher\BatchedApplyLowestPriceOnChannelPricingsCommandDispatcher"
         >
             <argument type="service" id="sylius.repository.channel_pricing" />
-            <argument type="service" id="sylius.no_transaction_command_bus" />
+            <argument type="service" id="sylius.command_bus" />
             <argument>%sylius_price_history.batch_size%</argument>
         </service>
     </services>

--- a/config/services/command_handlers.xml
+++ b/config/services/command_handlers.xml
@@ -18,7 +18,9 @@
         <service id="Sylius\PriceHistoryPlugin\Application\CommandHandler\ApplyLowestPriceOnChannelPricingsHandler">
             <argument type="service" id="Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface" />
             <argument type="service" id="sylius.repository.channel_pricing" />
-            <tag name="messenger.message_handler" bus="sylius.no_transaction_command_bus" />
+
+            <tag name="messenger.message_handler" bus="sylius.command_bus" />
+            <tag name="messenger.message_handler" bus="sylius_default.bus" />
         </service>
     </services>
 </container>

--- a/config/services/command_handlers.xml
+++ b/config/services/command_handlers.xml
@@ -18,7 +18,7 @@
         <service id="Sylius\PriceHistoryPlugin\Application\CommandHandler\ApplyLowestPriceOnChannelPricingsHandler">
             <argument type="service" id="Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface" />
             <argument type="service" id="sylius.repository.channel_pricing" />
-            <tag name="messenger.message_handler" bus="sylius.command_bus" />
+            <tag name="messenger.message_handler" bus="sylius.no_transaction_command_bus" />
         </service>
     </services>
 </container>

--- a/config/services/command_handlers.xml
+++ b/config/services/command_handlers.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="true" />
+
+        <service id="Sylius\PriceHistoryPlugin\Application\CommandHandler\ApplyLowestPriceOnChannelPricingsHandler">
+            <argument type="service" id="Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface" />
+            <argument type="service" id="sylius.repository.channel_pricing" />
+            <tag name="messenger.message_handler" bus="sylius.command_bus" />
+        </service>
+    </services>
+</container>

--- a/config/services/listeners.xml
+++ b/config/services/listeners.xml
@@ -22,9 +22,7 @@
         </service>
 
         <service id="Sylius\PriceHistoryPlugin\Infrastructure\EntityObserver\ProcessLowestPriceOnCheckingPeriodChangeObserver">
-            <argument type="service" id="Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface" />
-            <argument type="service" id="sylius.repository.channel_pricing" />
-            <argument>%sylius_price_history.batch_size%</argument>
+            <argument type="service" id="Sylius\PriceHistoryPlugin\Application\CommandDispatcher\ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface" />
             <tag name="sylius_price_history.entity_observer" />
         </service>
 

--- a/spec/Application/CommandDispatcher/BatchedApplyLowestPriceOnChannelPricingsCommandDispatcherSpec.php
+++ b/spec/Application/CommandDispatcher/BatchedApplyLowestPriceOnChannelPricingsCommandDispatcherSpec.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\PriceHistoryPlugin\Application\CommandDispatcher;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\PriceHistoryPlugin\Application\Command\ApplyLowestPriceOnChannelPricings;
+use Sylius\PriceHistoryPlugin\Application\CommandDispatcher\ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface;
+use Sylius\PriceHistoryPlugin\Application\CommandHandler\ApplyLowestPriceOnChannelPricingsHandler;
+use Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class BatchedApplyLowestPriceOnChannelPricingsCommandDispatcherSpec extends ObjectBehavior
+{
+    function let(RepositoryInterface $channelPricingRepository, MessageBusInterface $messageBus): void
+    {
+        $this->beConstructedWith($channelPricingRepository, $messageBus, 2);
+    }
+
+    function it_implements_apply_lowest_price_on_channel_pricings_command_dispatcher_interface(): void
+    {
+        $this->shouldImplement(ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface::class);
+    }
+
+    function it_dispatches_applications_of_lowest_price_on_channel_pricing_within_channel_in_batches(
+        RepositoryInterface $channelPricingRepository,
+        MessageBusInterface $messageBus,
+        ChannelInterface $channel,
+        ChannelPricingInterface $firstChannelPricing,
+        ChannelPricingInterface $secondChannelPricing,
+        ChannelPricingInterface $thirdChannelPricing,
+        ChannelPricingInterface $fourthChannelPricing,
+        ChannelPricingInterface $fifthChannelPricing,
+    ): void {
+        $channel->getCode()->willReturn('WEB');
+
+        $firstChannelPricing->getId()->willReturn(1);
+        $secondChannelPricing->getId()->willReturn(2);
+        $thirdChannelPricing->getId()->willReturn(6);
+        $fourthChannelPricing->getId()->willReturn(7);
+        $fifthChannelPricing->getId()->willReturn(9);
+
+        $batches = [
+            [
+                $firstChannelPricing->getWrappedObject(),
+                $secondChannelPricing->getWrappedObject(),
+            ],
+            [
+                $thirdChannelPricing->getWrappedObject(),
+                $fourthChannelPricing->getWrappedObject(),
+            ],
+            [
+                $fifthChannelPricing->getWrappedObject(),
+            ],
+            [],
+        ];
+
+        $batchSize = 2;
+
+        foreach ($batches as $key => $batch) {
+            $channelPricingRepository
+                ->findBy(['channelCode' => 'WEB'], ['id' => 'ASC'], 2, $key * $batchSize)
+                ->willReturn($batch)
+                ->shouldBeCalled()
+            ;
+        }
+
+        foreach ([[1, 2], [6, 7], [9]] as $ids) {
+            $messageBus
+                ->dispatch($command = new ApplyLowestPriceOnChannelPricings($ids))
+                ->willReturn(new Envelope($command))
+                ->shouldBeCalled()
+            ;
+        }
+
+        $this->applyWithinChannel($channel);
+    }
+}

--- a/spec/Application/CommandHandler/ApplyLowestPriceOnChannelPricingsHandlerSpec.php
+++ b/spec/Application/CommandHandler/ApplyLowestPriceOnChannelPricingsHandlerSpec.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\PriceHistoryPlugin\Application\CommandHandler;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\PriceHistoryPlugin\Application\Command\ApplyLowestPriceOnChannelPricings;
+use Sylius\PriceHistoryPlugin\Application\CommandHandler\ApplyLowestPriceOnChannelPricingsHandler;
+use Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
+
+final class ApplyLowestPriceOnChannelPricingsHandlerSpec extends ObjectBehavior
+{
+    function let(
+        ProductLowestPriceBeforeDiscountProcessorInterface $productLowestPriceBeforeDiscountProcessor,
+        RepositoryInterface $channelPricingRepository,
+    ): void {
+        $this->beConstructedWith($productLowestPriceBeforeDiscountProcessor, $channelPricingRepository);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(ApplyLowestPriceOnChannelPricingsHandler::class);
+    }
+
+    function it_applies_lowest_price_before_discount_on_all_given_channel_pricings(
+        ProductLowestPriceBeforeDiscountProcessorInterface $productLowestPriceBeforeDiscountProcessor,
+        RepositoryInterface $channelPricingRepository,
+        ChannelPricingInterface $firstChannelPricing,
+        ChannelPricingInterface $secondChannelPricing,
+        ChannelPricingInterface $thirdChannelPricing,
+    ): void {
+        $channelPricingRepository
+            ->findBy(['id' => [1, 3, 4]])
+            ->willReturn([
+                $firstChannelPricing->getWrappedObject(),
+                $secondChannelPricing->getWrappedObject(),
+                $thirdChannelPricing->getWrappedObject(),
+            ])
+        ;
+
+        $productLowestPriceBeforeDiscountProcessor->process($firstChannelPricing)->shouldBeCalled();
+        $productLowestPriceBeforeDiscountProcessor->process($secondChannelPricing)->shouldBeCalled();
+        $productLowestPriceBeforeDiscountProcessor->process($thirdChannelPricing)->shouldBeCalled();
+        $productLowestPriceBeforeDiscountProcessor->process(Argument::any())->shouldBeCalledTimes(3);
+
+        $this(new ApplyLowestPriceOnChannelPricings([1, 3, 4]));
+    }
+
+    function it_does_not_apply_lowest_price_before_discount_on_any_channel_pricing_if_there_are_no_given_channel_pricings(
+        ProductLowestPriceBeforeDiscountProcessorInterface $productLowestPriceBeforeDiscountProcessor,
+        RepositoryInterface $channelPricingRepository,
+    ): void {
+        $channelPricingRepository
+            ->findBy(['id' => []])
+            ->willReturn([])
+        ;
+
+        $productLowestPriceBeforeDiscountProcessor->process(Argument::any())->shouldNotBeCalled();
+
+        $this(new ApplyLowestPriceOnChannelPricings([]));
+    }
+}

--- a/spec/Infrastructure/EntityObserver/ProcessLowestPriceOnCheckingPeriodChangeObserverSpec.php
+++ b/spec/Infrastructure/EntityObserver/ProcessLowestPriceOnCheckingPeriodChangeObserverSpec.php
@@ -6,6 +6,7 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\PriceHistoryPlugin\Application\CommandDispatcher\ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface;
 use Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface;
 use Sylius\PriceHistoryPlugin\Domain\Model\ChannelInterface;
 use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
@@ -13,11 +14,9 @@ use Sylius\PriceHistoryPlugin\Infrastructure\EntityObserver\EntityObserverInterf
 
 final class ProcessLowestPriceOnCheckingPeriodChangeObserverSpec extends ObjectBehavior
 {
-    function let(
-        ProductLowestPriceBeforeDiscountProcessorInterface $productLowestPriceBeforeDiscountProcessor,
-        RepositoryInterface $channelPricingRepository,
-    ): void {
-        $this->beConstructedWith($productLowestPriceBeforeDiscountProcessor, $channelPricingRepository, 2);
+    function let(ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface $commandDispatcher): void
+    {
+        $this->beConstructedWith($commandDispatcher);
     }
 
     function it_implements_on_entity_change_interface(): void
@@ -38,61 +37,20 @@ final class ProcessLowestPriceOnCheckingPeriodChangeObserverSpec extends ObjectB
         $this->observedFields()->shouldReturn(['lowestPriceForDiscountedProductsCheckingPeriod']);
     }
 
-    function it_processes_product_lowest_price_for_each_channel_pricing_within_channel(
-        ProductLowestPriceBeforeDiscountProcessorInterface $productLowestPriceBeforeDiscountProcessor,
-        RepositoryInterface $channelPricingRepository,
+    function it_delegates_processing_lowest_prices_to_command_dispatcher(
+        ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface $commandDispatcher,
         ChannelInterface $channel,
-        ChannelPricingInterface $firstChannelPricing,
-        ChannelPricingInterface $secondChannelPricing,
-        ChannelPricingInterface $thirdChannelPricing,
-        ChannelPricingInterface $fourthChannelPricing,
-        ChannelPricingInterface $fifthChannelPricing,
     ): void {
-        $channel->getCode()->willReturn('WEB');
-
-        $batches = [
-            [
-                $firstChannelPricing->getWrappedObject(),
-                $secondChannelPricing->getWrappedObject(),
-            ],
-            [
-                $thirdChannelPricing->getWrappedObject(),
-                $fourthChannelPricing->getWrappedObject(),
-            ],
-            [
-                $fifthChannelPricing->getWrappedObject(),
-            ],
-            [],
-        ];
-
-        $batchSize = 2;
-
-        foreach ($batches as $key => $batch) {
-            $channelPricingRepository
-                ->findBy(['channelCode' => 'WEB'], ['id' => 'ASC'], 2, $key * $batchSize)
-                ->willReturn($batch)
-                ->shouldBeCalled()
-            ;
-        }
-
-        $productLowestPriceBeforeDiscountProcessor->process($firstChannelPricing)->shouldBeCalled();
-        $productLowestPriceBeforeDiscountProcessor->process($secondChannelPricing)->shouldBeCalled();
-        $productLowestPriceBeforeDiscountProcessor->process($thirdChannelPricing)->shouldBeCalled();
-        $productLowestPriceBeforeDiscountProcessor->process($fourthChannelPricing)->shouldBeCalled();
-        $productLowestPriceBeforeDiscountProcessor->process($fifthChannelPricing)->shouldBeCalled();
+        $commandDispatcher->applyWithinChannel($channel)->shouldBeCalled();
 
         $this->onChange($channel);
     }
 
     function it_throws_an_exception_if_entity_is_not_channel(
-        ProductLowestPriceBeforeDiscountProcessorInterface $productLowestPriceBeforeDiscountProcessor,
-        RepositoryInterface $channelPricingRepository,
+        ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface $commandDispatcher,
         OrderInterface $order,
     ): void {
-        $channelPricingRepository->findBy(Argument::any())->shouldNotBeCalled();
-
-        $productLowestPriceBeforeDiscountProcessor->process(Argument::any())->shouldNotBeCalled();
-        $productLowestPriceBeforeDiscountProcessor->process(Argument::any())->shouldNotBeCalled();
+        $commandDispatcher->applyWithinChannel(Argument::any())->shouldNotBeCalled();
 
         $this->shouldThrow(\InvalidArgumentException::class)->during('onChange', [$order]);
     }

--- a/src/Application/Command/ApplyLowestPriceOnChannelPricings.php
+++ b/src/Application/Command/ApplyLowestPriceOnChannelPricings.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Application\Command;
+
+final class ApplyLowestPriceOnChannelPricings
+{
+    public function __construct(public array $channelPricingIds)
+    {
+    }
+}

--- a/src/Application/CommandDispatcher/ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface.php
+++ b/src/Application/CommandDispatcher/ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Application\CommandDispatcher;
+
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelInterface;
+
+interface ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface
+{
+    public function applyWithinChannel(ChannelInterface $channel): void;
+}

--- a/src/Application/CommandDispatcher/BatchedApplyLowestPriceOnChannelPricingsCommandDispatcher.php
+++ b/src/Application/CommandDispatcher/BatchedApplyLowestPriceOnChannelPricingsCommandDispatcher.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Application\CommandDispatcher;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\PriceHistoryPlugin\Application\Command\ApplyLowestPriceOnChannelPricings;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class BatchedApplyLowestPriceOnChannelPricingsCommandDispatcher implements ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface
+{
+    public function __construct(
+        private RepositoryInterface $channelPricingRepository,
+        private MessageBusInterface $messageBus,
+        private int $batchSize,
+    ) {
+    }
+
+    public function applyWithinChannel(ChannelInterface $channel): void
+    {
+        $limit = $this->batchSize;
+        $offset = 0;
+
+        while ([] !== ($channelPricingsIds = $this->getIdsBatch($channel, $limit, $offset))) {
+            $this->messageBus->dispatch(new ApplyLowestPriceOnChannelPricings($channelPricingsIds));
+
+            $offset += $limit;
+        }
+    }
+
+    private function getIdsBatch(ChannelInterface $channel, int $limit, int $offset): array
+    {
+        /** @var ChannelPricingInterface[] $channelPricings */
+        $channelPricings = $this->channelPricingRepository->findBy(
+            ['channelCode' => $channel->getCode()],
+            ['id' => 'ASC'],
+            $limit,
+            $offset,
+        );
+
+        return (new ArrayCollection($channelPricings))
+            ->map(fn (ChannelPricingInterface $channelPricing): mixed => $channelPricing->getId())
+            ->getValues()
+        ;
+    }
+}

--- a/src/Application/CommandHandler/ApplyLowestPriceOnChannelPricingsHandler.php
+++ b/src/Application/CommandHandler/ApplyLowestPriceOnChannelPricingsHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PriceHistoryPlugin\Application\CommandHandler;
+
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\PriceHistoryPlugin\Application\Command\ApplyLowestPriceOnChannelPricings;
+use Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface;
+use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
+
+final class ApplyLowestPriceOnChannelPricingsHandler
+{
+    public function __construct(
+        private ProductLowestPriceBeforeDiscountProcessorInterface $productLowestPriceBeforeDiscountProcessor,
+        private RepositoryInterface $channelPricingRepository,
+    ) {
+    }
+
+    public function __invoke(ApplyLowestPriceOnChannelPricings $applyLowestPriceOnChannelPricings): void
+    {
+        /** @var ChannelPricingInterface[] $channelPricings */
+        $channelPricings = $this->channelPricingRepository->findBy(
+            ['id' => $applyLowestPriceOnChannelPricings->channelPricingIds],
+        );
+
+        foreach ($channelPricings as $channelPricing) {
+            $this->productLowestPriceBeforeDiscountProcessor->process($channelPricing);
+        }
+    }
+}

--- a/src/Infrastructure/EntityObserver/ProcessLowestPriceOnCheckingPeriodChangeObserver.php
+++ b/src/Infrastructure/EntityObserver/ProcessLowestPriceOnCheckingPeriodChangeObserver.php
@@ -19,6 +19,8 @@ use Webmozart\Assert\Assert;
 
 final class ProcessLowestPriceOnCheckingPeriodChangeObserver implements EntityObserverInterface
 {
+    private array $channelsCurrentlyProcessed = [];
+
     public function __construct(private ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface $commandDispatcher)
     {
     }
@@ -27,12 +29,16 @@ final class ProcessLowestPriceOnCheckingPeriodChangeObserver implements EntityOb
     {
         Assert::isInstanceOf($entity, ChannelInterface::class);
 
+        $this->channelsCurrentlyProcessed = [(string) $entity->getCode() => true];
+
         $this->commandDispatcher->applyWithinChannel($entity);
+
+        unset($this->channelsCurrentlyProcessed[(string) $entity->getCode()]);
     }
 
     public function supports(object $entity): bool
     {
-        return $entity instanceof ChannelInterface;
+        return $entity instanceof ChannelInterface && !isset($this->channelsCurrentlyProcessed[$entity->getCode()]);
     }
 
     public function observedFields(): array

--- a/src/Infrastructure/EntityObserver/ProcessLowestPriceOnCheckingPeriodChangeObserver.php
+++ b/src/Infrastructure/EntityObserver/ProcessLowestPriceOnCheckingPeriodChangeObserver.php
@@ -13,43 +13,21 @@ declare(strict_types=1);
 
 namespace Sylius\PriceHistoryPlugin\Infrastructure\EntityObserver;
 
-use Sylius\Component\Resource\Repository\RepositoryInterface;
-use Sylius\PriceHistoryPlugin\Application\Processor\ProductLowestPriceBeforeDiscountProcessorInterface;
+use Sylius\PriceHistoryPlugin\Application\CommandDispatcher\ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface;
 use Sylius\PriceHistoryPlugin\Domain\Model\ChannelInterface;
-use Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingInterface;
 use Webmozart\Assert\Assert;
 
 final class ProcessLowestPriceOnCheckingPeriodChangeObserver implements EntityObserverInterface
 {
-    public function __construct(
-        private ProductLowestPriceBeforeDiscountProcessorInterface $productLowestPriceBeforeDiscountProcessor,
-        private RepositoryInterface $channelPricingRepository,
-        private int $batchSize,
-    ) {
+    public function __construct(private ApplyLowestPriceOnChannelPricingsCommandDispatcherInterface $commandDispatcher)
+    {
     }
 
     public function onChange(object $entity): void
     {
         Assert::isInstanceOf($entity, ChannelInterface::class);
 
-        $limit = $this->batchSize;
-        $offset = 0;
-
-        do {
-            /** @var ChannelPricingInterface[] $channelPricings */
-            $channelPricings = $this->channelPricingRepository->findBy(
-                ['channelCode' => $entity->getCode()],
-                ['id' => 'ASC'],
-                $limit,
-                $offset,
-            );
-
-            foreach ($channelPricings as $channelPricing) {
-                $this->productLowestPriceBeforeDiscountProcessor->process($channelPricing);
-            }
-
-            $offset += $limit;
-        } while ([] !== $channelPricings);
+        $this->commandDispatcher->applyWithinChannel($entity);
     }
 
     public function supports(object $entity): bool


### PR DESCRIPTION
- [x] Add a command to apply the lowest price on a batch (eg. 100 channel pricings)
- [x] Add command dispatcher
- [x] make it async by default
- [x] Fix https://github.com/Sylius/PriceHistoryPlugin/pull/69#discussion_r1133115481