### PR TITLE
[BUG] Prevent calculating lowest price, when there is no discount

### DIFF
--- a/features/product/viewing_products/seeing_corresponding_lowest_price_before_discount_when_selecting_different_product_variant.feature
+++ b/features/product/viewing_products/seeing_corresponding_lowest_price_before_discount_when_selecting_different_product_variant.feature
@@ -11,6 +11,10 @@ Feature: Seeing the corresponding lowest price before the discount when selectin
         And the product "Wyborowa Vodka" has "Wyborowa Vodka 50%" variant priced at "$50.00"
         And the product "Wyborowa Vodka" has "Wyborowa Vodka 30%" variant priced at "$60.00"
         And there is a catalog promotion "Winter sale" with priority 1 that reduces price by "50%" and applies on "Wyborowa Vodka" product
+        And the store has a "Bocian Vodka" configurable product
+        And the product "Bocian Vodka" has "Bocian Vodka Caramel" variant priced at "$40.00"
+        And the product "Bocian Vodka" has "Bocian Vodka Advocate" variant priced at "$20.00"
+        And there is a catalog promotion "Summer sale" with priority 1 that reduces price by "50%" and applies on "Bocian Vodka Caramel" variant
 
     @no-api @ui @javascript
     Scenario: Seeing correct lowest price when selecting first variant from the list
@@ -31,3 +35,15 @@ Feature: Seeing the corresponding lowest price before the discount when selectin
         And I select "Wyborowa Vodka 30%" variant
         And I select "Wyborowa Vodka 40%" variant
         Then I should see "$40.00" as its lowest price before the discount
+
+    @no-api @ui @javascript
+    Scenario: Seeing the correct lowest price when selecting the first discounted variant from the list
+        When I view product "Bocian Vodka"
+        And I select "Bocian Vodka Caramel" variant
+        Then I should see "$40.00" as its lowest price before the discount
+
+    @no-api @ui @javascript
+    Scenario: Unable to see the lowest price when there is a discount on the first variant, but not on the selected variant
+        When I view product "Bocian Vodka"
+        And I select "Bocian Vodka Advocate" variant
+        Then I should not see information about its lowest price

--- a/templates/Shop/Product/Show/_variants.html.twig
+++ b/templates/Shop/Product/Show/_variants.html.twig
@@ -26,18 +26,22 @@
             </td>
             {% set appliedPromotions = channelPricing.appliedPromotions|map(promotion => ({'label': promotion.label, 'description': promotion.description})) %}
             {% set days = sylius.channel.lowestPriceForDiscountedProductsCheckingPeriod %}
-            {% set lowest_price_before_discount = money.calculateLowestPrice(variant) %}
+            {% set has_lowest_price = variant|sylius_has_lowest_price({'channel': sylius.channel})%}
+            {% set has_discount = variant|sylius_has_discount({'channel': sylius.channel}) %}
 
             <td class="sylius-product-variant-price"
                 data-applied-promotions="{{ appliedPromotions|json_encode }}"
-                {% if variant|sylius_has_discount({'channel': sylius.channel}) %}
+                {% if has_discount %}
                     data-original-price="{{ money.calculateOriginalPrice(variant) }}"
-                    data-product-lowest-price-before-the-discount="{{
-                        'sylius.ui.the_lowest_price_days_before_the_discount_was'|trans({
-                            '%days%': days,
-                            '%price%': lowest_price_before_discount
-                        })
-                    }}"
+                    {% if has_lowest_price %}
+                        {% set lowest_price_before_discount = money.calculateLowestPrice(variant) %}
+                        data-product-lowest-price-before-the-discount="{{
+                            'sylius.ui.the_lowest_price_days_before_the_discount_was'|trans({
+                                '%days%': days,
+                                '%price%': lowest_price_before_discount
+                            })
+                        }}"
+                    {% endif %}
                 {% endif %}>
                 {{ money.calculatePrice(variant) }}
             </td>


### PR DESCRIPTION
Lack of checking if the variants are actually discounted was causing error 500 as it couldn't calculate the money from the lowest price as it was null.

Before:
![image](https://user-images.githubusercontent.com/53942444/225895081-dfd03990-1e89-43d3-86e4-5adc1d9ab1d7.png)

After:

https://user-images.githubusercontent.com/53942444/225895155-2bb25451-ef8b-4a74-881d-c47093693972.mp4

