### PR TITLE
[Maintenance] Adjust names to Sylius codebase

### DIFF
--- a/config/admin_routing.yaml
+++ b/config/admin_routing.yaml
@@ -1,4 +1,4 @@
-sylius_price_history_admin_channel_pricing_log_entry_index:
+sylius_admin_channel_pricing_log_entry_index:
     path: products/{productId}/variants/{variantId}/channel-pricing/{channelPricingId}/channel-pricing-log-entries
     methods: [GET]
     defaults:

--- a/config/admin_routing.yaml
+++ b/config/admin_routing.yaml
@@ -7,7 +7,7 @@ sylius_admin_channel_pricing_log_entry_index:
             section: admin
             permission: true
             template: '@SyliusAdmin/Crud/index.html.twig'
-            grid: sylius_price_history_admin_channel_pricing_log_entry
+            grid: sylius_admin_channel_pricing_log_entry
             vars:
                 icon: book
                 templates:

--- a/config/doctrine/ChannelPricingLogEntry.orm.xml
+++ b/config/doctrine/ChannelPricingLogEntry.orm.xml
@@ -17,7 +17,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
 >
 
-    <mapped-superclass name="Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingLogEntry" table="sylius_price_history_channel_pricing_log_entry">
+    <mapped-superclass name="Sylius\PriceHistoryPlugin\Domain\Model\ChannelPricingLogEntry" table="sylius_channel_pricing_log_entry">
         <id name="id" column="id" type="integer">
             <generator />
         </id>

--- a/config/grids/channel_pricing_log_entry.yaml
+++ b/config/grids/channel_pricing_log_entry.yaml
@@ -1,6 +1,6 @@
 sylius_grid:
     grids:
-        sylius_price_history_admin_channel_pricing_log_entry:
+        sylius_admin_channel_pricing_log_entry:
             driver:
                 name: doctrine/orm
                 options:

--- a/spec/Infrastructure/Serializer/ChannelExcludedTaxonsDenormalizerSpec.php
+++ b/spec/Infrastructure/Serializer/ChannelExcludedTaxonsDenormalizerSpec.php
@@ -23,7 +23,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class ChannelExcludedTaxonsDenormalizerSpec extends ObjectBehavior
 {
-    private const ALREADY_CALLED = 'sylius_price_history_channel_excluded_taxons_denormalizer_already_called';
+    private const ALREADY_CALLED = 'sylius_channel_excluded_taxons_denormalizer_already_called';
 
     function let(IriConverterInterface $iriConverter): void
     {

--- a/src/Domain/Model/LowestPriceForDiscountedProductsAwareTrait.php
+++ b/src/Domain/Model/LowestPriceForDiscountedProductsAwareTrait.php
@@ -32,13 +32,13 @@ trait LowestPriceForDiscountedProductsAwareTrait
      * @var Collection|TaxonInterface[]
      *
      * @ORM\ManyToMany(targetEntity="Sylius\Component\Taxonomy\Model\TaxonInterface")
-     * @ORM\JoinTable(name="sylius_price_history_channel_excluded_taxons",
+     * @ORM\JoinTable(name="sylius_channel_excluded_taxons",
      *     joinColumns={@ORM\JoinColumn(name="channel_id", referencedColumnName="id", onDelete="CASCADE")},
      *     inverseJoinColumns={@ORM\JoinColumn(name="taxon_id", referencedColumnName="id", onDelete="CASCADE")}
      * )
      */
     #[ORM\ManyToMany(targetEntity: TaxonInterface::class)]
-    #[ORM\JoinTable(name: 'sylius_price_history_channel_excluded_taxons')]
+    #[ORM\JoinTable(name: 'sylius_channel_excluded_taxons')]
     #[ORM\JoinColumn(name: 'channel_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     #[ORM\InverseJoinColumn(name: 'taxon_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     protected Collection $taxonsExcludedFromShowingLowestPrice;

--- a/src/Infrastructure/Migrations/Version20230126131430.php
+++ b/src/Infrastructure/Migrations/Version20230126131430.php
@@ -27,16 +27,16 @@ final class Version20230126131430 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('CREATE TABLE sylius_price_history_channel_pricing_log_entry (id INT AUTO_INCREMENT NOT NULL, channel_pricing_id INT NOT NULL, price INT NOT NULL, original_price INT DEFAULT NULL, logged_at DATETIME NOT NULL, INDEX IDX_B3F5AAC23EADFFE5 (channel_pricing_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('ALTER TABLE sylius_price_history_channel_pricing_log_entry ADD CONSTRAINT FK_B3F5AAC23EADFFE5 FOREIGN KEY (channel_pricing_id) REFERENCES sylius_channel_pricing (id) ON DELETE CASCADE');
-        $this->addSql('INSERT INTO `sylius_price_history_channel_pricing_log_entry` (`channel_pricing_id`, `price`, `original_price`, `logged_at`) SELECT `id`, `price`, `original_price`, NOW() FROM `sylius_channel_pricing`');
+        $this->addSql('CREATE TABLE sylius_channel_pricing_log_entry (id INT AUTO_INCREMENT NOT NULL, channel_pricing_id INT NOT NULL, price INT NOT NULL, original_price INT DEFAULT NULL, logged_at DATETIME NOT NULL, INDEX IDX_B3F5AAC23EADFFE5 (channel_pricing_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE sylius_channel_pricing_log_entry ADD CONSTRAINT FK_B3F5AAC23EADFFE5 FOREIGN KEY (channel_pricing_id) REFERENCES sylius_channel_pricing (id) ON DELETE CASCADE');
+        $this->addSql('INSERT INTO `sylius_channel_pricing_log_entry` (`channel_pricing_id`, `price`, `original_price`, `logged_at`) SELECT `id`, `price`, `original_price`, NOW() FROM `sylius_channel_pricing`');
     }
 
     public function down(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE sylius_price_history_channel_pricing_log_entry DROP FOREIGN KEY FK_B3F5AAC23EADFFE5');
-        $this->addSql('DROP TABLE sylius_price_history_channel_pricing_log_entry');
+        $this->addSql('ALTER TABLE sylius_channel_pricing_log_entry DROP FOREIGN KEY FK_B3F5AAC23EADFFE5');
+        $this->addSql('DROP TABLE sylius_channel_pricing_log_entry');
     }
 }

--- a/src/Infrastructure/Migrations/Version20230222143342.php
+++ b/src/Infrastructure/Migrations/Version20230222143342.php
@@ -30,17 +30,17 @@ final class Version20230222143342 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('CREATE TABLE sylius_price_history_channel_excluded_taxons (channel_id INT NOT NULL, taxon_id INT NOT NULL, INDEX IDX_C5BAE23572F5A1AA (channel_id), INDEX IDX_C5BAE235DE13F470 (taxon_id), PRIMARY KEY(channel_id, taxon_id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('ALTER TABLE sylius_price_history_channel_excluded_taxons ADD CONSTRAINT FK_C5BAE23572F5A1AA FOREIGN KEY (channel_id) REFERENCES sylius_channel (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE sylius_price_history_channel_excluded_taxons ADD CONSTRAINT FK_C5BAE235DE13F470 FOREIGN KEY (taxon_id) REFERENCES sylius_taxon (id) ON DELETE CASCADE');
+        $this->addSql('CREATE TABLE sylius_channel_excluded_taxons (channel_id INT NOT NULL, taxon_id INT NOT NULL, INDEX IDX_C5BAE23572F5A1AA (channel_id), INDEX IDX_C5BAE235DE13F470 (taxon_id), PRIMARY KEY(channel_id, taxon_id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE sylius_channel_excluded_taxons ADD CONSTRAINT FK_C5BAE23572F5A1AA FOREIGN KEY (channel_id) REFERENCES sylius_channel (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sylius_channel_excluded_taxons ADD CONSTRAINT FK_C5BAE235DE13F470 FOREIGN KEY (taxon_id) REFERENCES sylius_taxon (id) ON DELETE CASCADE');
     }
 
     public function down(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE sylius_price_history_channel_excluded_taxons DROP FOREIGN KEY FK_C5BAE23572F5A1AA');
-        $this->addSql('ALTER TABLE sylius_price_history_channel_excluded_taxons DROP FOREIGN KEY FK_C5BAE235DE13F470');
-        $this->addSql('DROP TABLE sylius_price_history_channel_excluded_taxons');
+        $this->addSql('ALTER TABLE sylius_channel_excluded_taxons DROP FOREIGN KEY FK_C5BAE23572F5A1AA');
+        $this->addSql('ALTER TABLE sylius_channel_excluded_taxons DROP FOREIGN KEY FK_C5BAE235DE13F470');
+        $this->addSql('DROP TABLE sylius_channel_excluded_taxons');
     }
 }

--- a/src/Infrastructure/Serializer/ChannelExcludedTaxonsDenormalizer.php
+++ b/src/Infrastructure/Serializer/ChannelExcludedTaxonsDenormalizer.php
@@ -25,7 +25,7 @@ final class ChannelExcludedTaxonsDenormalizer implements ContextAwareDenormalize
 {
     use DenormalizerAwareTrait;
 
-    private const ALREADY_CALLED = 'sylius_price_history_channel_excluded_taxons_denormalizer_already_called';
+    private const ALREADY_CALLED = 'sylius_channel_excluded_taxons_denormalizer_already_called';
 
     public function __construct(private IriConverterInterface $iriConverter)
     {

--- a/templates/Admin/Product/Show/_pricing.html.twig
+++ b/templates/Admin/Product/Show/_pricing.html.twig
@@ -29,7 +29,7 @@
                             {% include '@SyliusAdmin/Product/Show/_appliedPromotions.html.twig' %}
                         {% endif %}
                         <td>
-                            <a class="ui blue labeled icon button" href="{{ path('sylius_price_history_admin_channel_pricing_log_entry_index', {
+                            <a class="ui blue labeled icon button" href="{{ path('sylius_admin_channel_pricing_log_entry_index', {
                                 'productId': product.id,
                                 'variantId': product.variants.first.id,
                                 'channelPricingId': channelPricing.id

--- a/templates/Admin/Product/Show/_variantContentPricing.html.twig
+++ b/templates/Admin/Product/Show/_variantContentPricing.html.twig
@@ -30,7 +30,7 @@
                         {% include '@SyliusAdmin/Product/Show/_appliedPromotions.html.twig' %}
                     {% endif %}
                     <td>
-                        <a class="ui blue labeled icon button" href="{{ path('sylius_price_history_admin_channel_pricing_log_entry_index', {
+                        <a class="ui blue labeled icon button" href="{{ path('sylius_admin_channel_pricing_log_entry_index', {
                             'productId': product.id,
                             'variantId': variant.id,
                             'channelPricingId': channelPricing.id

--- a/tests/Behat/Resources/services/pages/price_history.xml
+++ b/tests/Behat/Resources/services/pages/price_history.xml
@@ -14,7 +14,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sylius_price_history.behat.page.admin.channel_pricing_log_entry.index" class="Tests\Sylius\PriceHistoryPlugin\Behat\Page\Admin\ChannelPricingLogEntry\IndexPage" parent="sylius.behat.page.admin.crud.index" public="true">
-            <argument>sylius_price_history_admin_channel_pricing_log_entry_index</argument>
+            <argument>sylius_admin_channel_pricing_log_entry_index</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
As we are aware that this functionality will be moved to Sylius, in order to make the upgrade between using the plugin and using this functionality in the new version of Sylius as simple as possible, I would like to adjust the names of some of the configurations, in case someone customises them in the end application.