### PR TITLE
[Psalm] Add EventSubscriberInterface to the deprecated classes list

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -49,6 +49,7 @@
 
         <DeprecatedInterface>
             <errorLevel type="info">
+                <referencedClass name="Doctrine\Bundle\DoctrineBundle\EventSubscriber\EventSubscriberInterface" /> <!-- deprecated in DoctrineBundle 2.10.0 -->
                 <referencedClass name="Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface" /> <!-- deprecated in Symfony 6.1 -->
                 <referencedClass name="Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface" /> <!-- deprecated in Symfony 6.1 -->
             </errorLevel>


### PR DESCRIPTION
Fixes:
<img width="1050" alt="image" src="https://github.com/Sylius/PriceHistoryPlugin/assets/40125720/7c15c2a2-5513-4864-a8ca-a3b463cf1074">
