### PR TITLE
Fix money format (add locale code to moneyFormatter)

### DIFF
--- a/config/services/providers.xml
+++ b/config/services/providers.xml
@@ -18,6 +18,7 @@
             <argument type="service" id="sylius.calculator.product_variant_price" />
             <argument type="service" id="sylius.money_formatter" />
             <argument type="service" id="translator" />
+            <argument type="service" id="sylius.context.locale" />
         </service>
     </services>
 </container>

--- a/src/Infrastructure/Provider/ProductVariantsPricesProvider.php
+++ b/src/Infrastructure/Provider/ProductVariantsPricesProvider.php
@@ -21,6 +21,7 @@ use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Provider\ProductVariantsPricesProviderInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Product\Model\ProductOptionValueInterface;
 use Sylius\PriceHistoryPlugin\Application\Calculator\ProductVariantLowestPriceCalculatorInterface;
 use Sylius\PriceHistoryPlugin\Domain\Model\ChannelInterface;
@@ -34,6 +35,7 @@ final class ProductVariantsPricesProvider implements ProductVariantsPricesProvid
         private ProductVariantPricesCalculatorInterface $productVariantPriceCalculator,
         private MoneyFormatterInterface $moneyFormatter,
         private TranslatorInterface $translator,
+        private LocaleContextInterface $localeContext,
     ) {
     }
 
@@ -71,6 +73,9 @@ final class ProductVariantsPricesProvider implements ProductVariantsPricesProvid
         /** @var string $currencyCode */
         $currencyCode = $currency->getCode();
 
+        /** @var string $localeCode */
+        $localeCode = $this->localeContext->getLocaleCode();
+
         $lowestPriceBeforeDiscount = $this->productVariantLowestPriceCalculator
             ->calculateLowestPriceBeforeDiscount($variant, ['channel' => $channel])
         ;
@@ -84,6 +89,7 @@ final class ProductVariantsPricesProvider implements ProductVariantsPricesProvid
                     '%price%' => $this->moneyFormatter->format(
                         $lowestPriceBeforeDiscount,
                         $currencyCode,
+                        $localeCode
                     ),
                 ],
             );


### PR DESCRIPTION
This PR fixes a money formatting bug.

The error occurs for products for which the "Variant selection method" option is marked on "Options matching". For pl_PL locale, the price is shown as PLN 44.24 instead of 44,24 zł.

