### PR TITLE
Add German Translations for Price History Plugin

### DIFF
--- a/translations/messages+intl-icu.de.yaml
+++ b/translations/messages+intl-icu.de.yaml
@@ -1,0 +1,5 @@
+sylius:
+    ui:
+        lowest_price_days_before_discount_was: '{days, plural, 
+            one {Der niedrigste Preis dieses Produkts war vor # Tag vor dem aktuellen Rabatt {price}} 
+            other {Der niedrigste Preis dieses Produkts war vor # Tagen vor dem aktuellen Rabatt {price}}}'

--- a/translations/messages.de.yaml
+++ b/translations/messages.de.yaml
@@ -1,0 +1,13 @@
+sylius:
+    form:
+        admin:
+            channel:
+                lowest_price_for_discounted_products_visible: 'Soll der niedrigste Preis von reduzierten Produkten vor dem aktuellen Rabatt angezeigt werden?'
+                period_for_which_the_lowest_price_is_calculated: 'Zeitraum, für den der niedrigste Preis berechnet wird'
+    ui:
+        channel_pricing_history: 'Preishistorie für den Kanal'
+        days: 'Tage'
+        price_history: 'Preishistorie'
+        show_history_for_channel_pricing: 'Historie für die Kanalpreisgestaltung anzeigen'
+        taxons_for_which_the_lowest_price_is_not_displayed: 'Taxonomien, für die der niedrigste Preis nicht angezeigt wird'
+        lowest_price_before_discount: 'Niedrigster Preis vor Rabatt'

--- a/translations/validators.de.yaml
+++ b/translations/validators.de.yaml
@@ -1,0 +1,5 @@
+sylius:
+    channel_price_history_config:
+        lowest_price_for_discounted_products_checking_period:
+            greater_than: 'Der Wert muss größer sein als {{ compared_value }}'
+            less_than: 'Der Wert muss kleiner sein als {{ compared_value }}'


### PR DESCRIPTION
This pull request adds German translations for various messages in the Sylius Price History Plugin. The translations include:

- UI elements related to pricing history and discount displays.
- Input validation messages for checking price periods.

These translations aim to enhance the user experience for German-speaking users by providing localized messages that improve usability and accessibility.

Changes include:
- German translations for UI labels and input validation messages.

By including these translations, we maintain consistency with existing localization efforts within the Sylius project.
